### PR TITLE
feat: Add Claude Code statusline integration

### DIFF
--- a/src/configurators/statusline.js
+++ b/src/configurators/statusline.js
@@ -2,11 +2,14 @@
 import chalk from 'chalk';
 import { exec, spawn } from 'child_process';
 import { promisify } from 'util';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 
 const execAsync = promisify(exec);
 
 /**
- * Configure Claude Code statusline using @chongdashu/cc-statusline
+ * Configure statusline for Claude Code with enhanced monitoring features
  * @param {boolean} install - Whether to install the statusline
  * @returns {Promise<boolean>} Success status
  */
@@ -20,7 +23,8 @@ export async function configureStatusline(install = false) {
   try {
     // Check if Claude Code is installed first
     try {
-      await execAsync('which claude');
+      const command = process.platform === 'win32' ? 'where claude' : 'which claude';
+      await execAsync(command);
     } catch (error) {
       console.log(chalk.yellow('⚠ Claude Code is not installed. Skipping statusline setup.'));
       console.log(chalk.gray('  You can set it up later with: npx @chongdashu/cc-statusline@latest init'));
@@ -57,7 +61,8 @@ export async function configureStatusline(install = false) {
           console.log(chalk.gray('  🎨 256-color support'));
 
           // Check if jq is installed for full functionality
-          execAsync('which jq').then(() => {
+          const jqCommand = process.platform === 'win32' ? 'where jq' : 'which jq';
+          execAsync(jqCommand).then(() => {
             console.log(chalk.green('\n✓ jq is installed - All features available'));
             resolve(true);
           }).catch(() => {
@@ -102,8 +107,8 @@ export async function configureStatusline(install = false) {
 export async function isStatuslineConfigured() {
   try {
     // Check if the statusline configuration exists
-    const { stdout } = await execAsync('test -f ~/.config/claude/statusline.sh && echo "exists" || echo "not found"');
-    const result = stdout.trim() === 'exists';
+    const statuslinePath = path.join(os.homedir(), '.config', 'claude', 'statusline.sh');
+    const result = fs.existsSync(statuslinePath);
 
     if (process.env.DEBUG) {
       console.log(`[DEBUG] Statusline configured: ${result}`);
@@ -138,7 +143,8 @@ export async function getStatuslineStatus() {
     // Check if jq is installed for full features
     let hasJq = false;
     try {
-      await execAsync('which jq');
+      const jqCommand = process.platform === 'win32' ? 'where jq' : 'which jq';
+      await execAsync(jqCommand);
       hasJq = true;
     } catch (error) {
       hasJq = false;

--- a/src/configurators/statusline.js
+++ b/src/configurators/statusline.js
@@ -1,0 +1,156 @@
+// Statusline configuration for Claude Code
+import chalk from 'chalk';
+import { exec, spawn } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+/**
+ * Configure Claude Code statusline using @chongdashu/cc-statusline
+ * @param {boolean} install - Whether to install the statusline
+ * @returns {Promise<boolean>} Success status
+ */
+export async function configureStatusline(install = false) {
+  if (!install) {
+    return true;
+  }
+
+  console.log(chalk.cyan('\n🚀 Setting up Claude Code statusline...'));
+
+  try {
+    // Check if Claude Code is installed first
+    try {
+      await execAsync('which claude');
+    } catch (error) {
+      console.log(chalk.yellow('⚠ Claude Code is not installed. Skipping statusline setup.'));
+      console.log(chalk.gray('  You can set it up later with: npx @chongdashu/cc-statusline@latest init'));
+      return true;
+    }
+
+    // Instead of running the command directly, we'll use spawn to handle the interactive process
+    console.log(chalk.cyan('\nRunning statusline setup...'));
+    console.log(chalk.gray('This will configure your Claude Code terminal with enhanced features.\n'));
+
+    return new Promise((resolve) => {
+      const child = spawn('npx', ['@chongdashu/cc-statusline@latest', 'init'], {
+        stdio: 'inherit',
+        shell: true
+      });
+
+      child.on('close', (code) => {
+        if (code !== 0) {
+          console.log(chalk.yellow('\n⚠ Statusline setup was cancelled or encountered an issue.'));
+          console.log(chalk.gray('  You can try again manually: npx @chongdashu/cc-statusline@latest init'));
+          resolve(false);
+        } else {
+          console.log(chalk.green('\n✅ Claude Code statusline configured successfully!'));
+
+          // Show what features were enabled
+          console.log(chalk.cyan('\n✨ Statusline features enabled:'));
+          console.log(chalk.gray('  📁 Current directory with ~ abbreviation'));
+          console.log(chalk.gray('  🌿 Git branch information'));
+          console.log(chalk.gray('  🤖 Claude model and version info'));
+          console.log(chalk.gray('  🧠 Real-time context usage'));
+          console.log(chalk.gray('  💰 Cost tracking and burn rates'));
+          console.log(chalk.gray('  ⌛ Session timer'));
+          console.log(chalk.gray('  📊 Token analytics'));
+          console.log(chalk.gray('  🎨 256-color support'));
+
+          // Check if jq is installed for full functionality
+          execAsync('which jq').then(() => {
+            console.log(chalk.green('\n✓ jq is installed - All features available'));
+            resolve(true);
+          }).catch(() => {
+            console.log(chalk.yellow('\n⚠ jq is not installed - Some features may be limited'));
+            console.log(chalk.gray('  Install jq for full functionality:'));
+
+            // Provide OS-specific installation instructions
+            const platform = process.platform;
+            if (platform === 'darwin') {
+              console.log(chalk.gray('    brew install jq'));
+            } else if (platform === 'linux') {
+              console.log(chalk.gray('    sudo apt-get install jq  # Ubuntu/Debian'));
+              console.log(chalk.gray('    sudo yum install jq      # RHEL/CentOS'));
+            } else if (platform === 'win32') {
+              console.log(chalk.gray('    choco install jq         # Using Chocolatey'));
+              console.log(chalk.gray('    scoop install jq         # Using Scoop'));
+            }
+            resolve(true);
+          });
+        }
+      });
+
+      child.on('error', (error) => {
+        console.log(chalk.red('\n❌ Failed to start statusline setup'));
+        console.error(chalk.red(`  Error: ${error.message}`));
+        console.log(chalk.gray('\n  You can try manually: npx @chongdashu/cc-statusline@latest init'));
+        resolve(false);
+      });
+    });
+  } catch (error) {
+    console.log(chalk.red('\n❌ Failed to configure statusline'));
+    console.error(chalk.red(`  Error: ${error.message}`));
+    console.log(chalk.gray('\n  You can try manually: npx @chongdashu/cc-statusline@latest init'));
+    return false;
+  }
+}
+
+/**
+ * Check if statusline is already configured
+ * @returns {Promise<boolean>} Whether statusline is configured
+ */
+export async function isStatuslineConfigured() {
+  try {
+    // Check if the statusline configuration exists
+    const { stdout } = await execAsync('test -f ~/.config/claude/statusline.sh && echo "exists" || echo "not found"');
+    const result = stdout.trim() === 'exists';
+
+    if (process.env.DEBUG) {
+      console.log(`[DEBUG] Statusline configured: ${result}`);
+    }
+
+    return result;
+  } catch (error) {
+    return false;
+  }
+}
+
+/**
+ * Get statusline configuration status
+ * @returns {Promise<Object>} Status object with details
+ */
+export async function getStatuslineStatus() {
+  try {
+    const configured = await isStatuslineConfigured();
+
+    if (!configured) {
+      return {
+        configured: false,
+        message: 'Statusline not configured'
+      };
+    }
+
+    // Check if jq is installed for full features
+    let hasJq = false;
+    try {
+      await execAsync('which jq');
+      hasJq = true;
+    } catch (error) {
+      hasJq = false;
+    }
+
+    return {
+      configured: true,
+      hasJq,
+      message: hasJq
+        ? 'Statusline configured with full features'
+        : 'Statusline configured (limited features - jq not installed)'
+    };
+  } catch (error) {
+    return {
+      configured: false,
+      error: error.message,
+      message: 'Unable to check statusline status'
+    };
+  }
+}

--- a/src/utils/prompts.js
+++ b/src/utils/prompts.js
@@ -202,3 +202,24 @@ export async function confirmOverride(locations) {
 
   return confirmed;
 }
+
+export async function promptStatuslineSetup() {
+  console.log(chalk.cyan('\n🎨 Claude Code Statusline'));
+  console.log(chalk.gray('═'.repeat(50)));
+  console.log(chalk.white('Enhance your Claude Code terminal with:'));
+  console.log(chalk.gray('  📁 Directory display with ~ abbreviation'));
+  console.log(chalk.gray('  🌿 Git branch information'));
+  console.log(chalk.gray('  🤖 Model info and version'));
+  console.log(chalk.gray('  🧠 Real-time context usage'));
+  console.log(chalk.gray('  💰 Cost tracking and burn rates'));
+  console.log(chalk.gray('  ⌛ Session timer'));
+  console.log(chalk.gray('  📊 Token analytics'));
+  console.log(chalk.gray('═'.repeat(50)));
+
+  const wantsStatusline = await confirm({
+    message: 'Would you like to setup Claude Code statusline?',
+    default: true
+  });
+
+  return wantsStatusline;
+}


### PR DESCRIPTION
## Summary

This PR enhances the MegaLLM setup tool with optional Claude Code statusline configuration, providing users with a richer terminal experience. The statusline integration is offered after Claude Code configuration and includes comprehensive features for monitoring usage, costs, and git information.

### Key Changes

- **New Statusline Module** (`src/configurators/statusline.js`):
  - `configureStatusline()` - Handles installation via @chongdashu/cc-statusline
  - `isStatuslineConfigured()` - Checks for existing configuration
  - `getStatuslineStatus()` - Returns detailed status information
  - Spawns interactive npx process for user-friendly setup
  - Provides OS-specific jq installation instructions

- **Enhanced CLI Flow** (`src/cli.js`):
  - Added statusline prompt after Claude Code configuration
  - Integrated check for existing statusline configuration
  - Added statusline setup in both new setup and existing config flows
  - Provides graceful fallback instructions if setup is skipped

- **New User Prompt** (`src/utils/prompts.js`):
  - `promptStatuslineSetup()` - Interactive prompt with feature list
  - Displays all statusline features with emoji indicators
  - Default set to true for opt-in by default

### Statusline Features

The integration enables users to access these features:
- 📁 Current directory with ~ abbreviation
- 🌿 Git branch information
- 🤖 Claude model and version info
- 🧠 Real-time context usage tracking
- 💰 Cost tracking and burn rates
- ⌛ Session timer
- 📊 Token analytics
- 🎨 256-color terminal support

### User Experience

1. **New Installations**: After configuring Claude Code, users are prompted to set up statusline
2. **Existing Configurations**: When skipping reconfiguration, statusline setup is still offered if not present
3. **Already Configured**: Detection prevents redundant setup prompts
4. **Opt-out Available**: Users can skip and receive manual setup instructions

### Technical Implementation

- Uses `spawn` with `stdio: 'inherit'` for interactive setup
- Checks Claude Code installation before proceeding
- Verifies jq dependency and provides installation guidance
- Non-blocking - setup failure doesn't prevent MegaLLM configuration
- Provides clear feedback at each step

## Test Plan

- [x] Test with Claude Code already installed
- [x] Test with statusline already configured (should skip)
- [x] Test with statusline not configured (should prompt)
- [x] Test opting in to statusline setup
- [x] Test opting out of statusline setup
- [x] Test with jq installed (full features)
- [x] Test without jq (should show installation instructions)
- [x] Test on macOS (primary platform)
- [x] Test on Linux
- [x] Test on Windows
- [x] Test existing configuration flow (skip reconfiguration path)
- [x] Test new installation flow
- [x] Verify fallback instructions are displayed when needed

## Breaking Changes

None. This is a purely additive feature that doesn't modify existing behavior.

## Dependencies

- Uses `@chongdashu/cc-statusline` package (installed via npx)
- Optional dependency on `jq` for full feature set (not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)