### PR TITLE
megallm 2.0: OAuth login, profiles/orgs, Ink hub + doctor key-health & auto-repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,439 +1,370 @@
-# MegaLLM Setup Tool
+# MegaLLM CLI
 
 <div align="center">
 
-  <h3>🚀 Configure Claude Code & Codex for MegaLLM with One Command</h3>
+  <h3>Sign in once. Use Claude Code, Codex, and OpenCode through MegaLLM.</h3>
 
   [![NPM Version](https://img.shields.io/npm/v/megallm.svg)](https://www.npmjs.com/package/megallm)
   [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-  [![Platform Support](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)](https://github.com/Megallm/megallm-npm)
+  [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)](https://github.com/Megallm/megallm-npm)
 
-  [**Quick Start**](#-quick-start) • [**Features**](#-features) • [**How It Works**](#-how-it-works) • [**Documentation**](#-documentation) • [**Support**](#-support)
+  [**Quick Start**](#quick-start) • [**Commands**](#commands) • [**OpenCode**](#configuring-opencode) • [**Profiles**](#profiles) • [**Troubleshooting**](#troubleshooting)
 
 </div>
 
 ---
 
-## 🎯 Quick Start
+## Quick Start
 
 ```bash
 npx megallm@latest
 ```
 
-That's it! The interactive CLI will guide you through the entire setup process.
+Lands on the interactive hub: shows your current account, detects installed tools, and lets you sign in or configure them with a single arrow-key choice.
 
-## ✨ Features
-
-<table>
-<tr>
-<td width="50%">
-
-### 🔍 Smart Detection
-- Auto-detects installed AI tools
-- Identifies your OS and shell
-- Checks existing configurations
-
-</td>
-<td width="50%">
-
-### 🔧 Automated Setup
-- Interactive configuration wizard
-- API key creation guidance
-- Environment variable management
-
-</td>
-</tr>
-<tr>
-<td width="50%">
-
-### 🔐 Secure & Safe
-- Automatic configuration backups
-- Secure API key storage
-- Project-level isolation support
-
-</td>
-<td width="50%">
-
-### 🌍 Universal Support
-- Works on macOS, Linux, Windows
-- Supports bash, zsh, fish, PowerShell
-- System or project-level configs
-
-</td>
-</tr>
-</table>
-
-## 📊 How It Works
-
-<div align="center">
-
-### 🔄 Setup Process Flow
-
-```
-┌──────────────────────────────────────────────────────┐
-│                   npx megallm                        │
-└────────────────────────┬─────────────────────────────┘
-                         ▼
-┌──────────────────────────────────────────────────────┐
-│          🔍 Environment Detection                    │
-├──────────────────────────────────────────────────────┤
-│  • Operating System (Mac/Linux/Win)                  │
-│  • Shell Type (bash/zsh/fish/PS)                     │
-│  • Installed Tools (Claude/Codex)                    │
-└────────────────────────┬─────────────────────────────┘
-                         ▼
-┌──────────────────────────────────────────────────────┐
-│          🔑 API Key Setup                            │
-├──────────────────────────────────────────────────────┤
-│  Have API Key?                                       │
-│    ├─ No  → Opens megallm.io                        │
-│    │        Shows instructions                       │
-│    │        Waits for key entry                      │
-│    └─ Yes → Enter API key                           │
-└────────────────────────┬─────────────────────────────┘
-                         ▼
-┌──────────────────────────────────────────────────────┐
-│          ⚙️ Configuration Choice                     │
-├──────────────────────────────────────────────────────┤
-│  Tool Selection:                                     │
-│    • Claude Code only                                │
-│    • Codex/Windsurf only                            │
-│    • Both tools                                      │
-│                                                      │
-│  Setup Level:                                        │
-│    • System (~/.claude, ~/.codex)                    │
-│    • Project (./.claude, ./.codex)                   │
-└────────────────────────┬─────────────────────────────┘
-                         ▼
-┌──────────────────────────────────────────────────────┐
-│          📝 Apply Configuration                      │
-├──────────────────────────────────────────────────────┤
-│  • Create/update config files                        │
-│  • Set environment variables                         │
-│  • Backup existing configs                           │
-│  • Reload shell if needed                            │
-└────────────────────────┬─────────────────────────────┘
-                         ▼
-┌──────────────────────────────────────────────────────┐
-│                  ✅ Complete!                        │
-└──────────────────────────────────────────────────────┘
-```
-
-</div>
-
-## 📦 Installation Options
-
-<details>
-<summary><b>🚀 Quick Run (Recommended)</b></summary>
+Prefer a one-shot command? All of these work too:
 
 ```bash
-# Latest version
+npx megallm login              # OAuth device flow → saves a key
+npx megallm setup              # Full wizard (sign in or paste a key, configure tools)
+npx megallm link claude        # Wire one tool with the saved key
+npx megallm doctor             # Diagnose every check
+```
+
+---
+
+## Why MegaLLM CLI
+
+- **Single sign-in** for Claude Code, Codex, and OpenCode — no copy-pasting keys per tool.
+- **OAuth device flow** (RFC 8628) opens the browser, lands on `/activate`, mints a per-org API key.
+- **Surgical config edits** — your existing settings (other providers, custom plugins, model overrides) are preserved.
+- **Multi-profile** — keep work and personal accounts side-by-side under `~/.megallm/profiles/`.
+- **Scriptable** — every interactive screen has a non-TTY plain-text equivalent for CI.
+
+---
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `megallm` | Open the interactive hub (auto-detects TTY; prints `--help` when piped). |
+| `megallm setup` | Full wizard: sign in or paste a key, then configure detected tools. |
+| `megallm login` | OAuth device flow. After success, asks if you want to wire detected tools. |
+| `megallm logout` | Revoke the saved key on the server and clear local creds. |
+| `megallm whoami` | Identity behind the current saved key. |
+| `megallm status` | Plain-text snapshot of identity + detected tools. |
+| `megallm doctor` | Run every health check (creds, tool configs, env vars). |
+| `megallm orgs` | List orgs you can switch into. |
+| `megallm switch-org [<id>]` | Switch active org and mint a fresh per-org key. Picker is interactive. |
+| `megallm keys list [--org <id>]` | List API keys in the active (or given) org. |
+| `megallm keys revoke <key_id>` | Revoke a key by id. |
+| `megallm link <tool>` | Wire one tool (`claude`, `codex`, `opencode`). |
+| `megallm unlink <tool>` | Surgically remove the MegaLLM keys from one tool. |
+| `megallm profile list` | List saved credential profiles. |
+| `megallm profile use <name>` | Make `<name>` the active profile. |
+| `megallm profile rm <name>` | Delete a saved profile. |
+
+Global flags: `--profile <name>` (or `-p`, also `MEGALLM_PROFILE` env), `--help`, `--version`.
+
+---
+
+## How It Works
+
+```
+            ┌─────────────────────────────────┐
+            │  npx megallm  (interactive hub) │
+            └────────────────┬────────────────┘
+                             │
+        ┌────────────────────┼────────────────────┐
+        ▼                    ▼                    ▼
+   megallm login       megallm setup        megallm link <tool>
+        │                    │                    │
+        ▼                    ▼                    ▼
+   /activate page     wizard chooses     wire one tool only
+   browser approve   tools + level + key
+        │                    │                    │
+        └─────── api key ────┴──── apiKey ────────┘
+                             │
+                             ▼
+            ┌─────────────────────────────────┐
+            │ ~/.megallm/profiles/<name>/     │
+            │   auth.json   (chmod 0600)      │
+            │   state.json                    │
+            └────────────────┬────────────────┘
+                             │
+       ┌─────────────────────┼─────────────────────┐
+       ▼                     ▼                     ▼
+   Claude Code           Codex                 OpenCode
+   ~/.claude/         ~/.codex/             ~/.config/opencode/
+   settings.json      config.toml           opencode.json
+```
+
+---
+
+## What Gets Written Where
+
+### Claude Code — `~/.claude/settings.json`
+
+The CLI **adds** these two env keys, leaves everything else untouched:
+
+```jsonc
+{
+  // …your existing config (theme, model, plugins) is preserved…
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://ai.megallm.io",
+    "ANTHROPIC_API_KEY": "sk-mega-…"
+  }
+}
+```
+
+It also approves the key prefix in `~/.claude.json` so Claude Code stops re-prompting.
+
+### Codex — `~/.codex/config.toml`
+
+Adds a `megallm` provider, switches `model_provider` to it, leaves your other providers in place:
+
+```toml
+model_provider = "megallm"
+model = "gpt-5"
+
+[model_providers.megallm]
+name = "OpenAI using Chat Completions"
+base_url = "https://ai.megallm.io/v1"
+env_key = "MEGALLM_API_KEY"
+query_params = {}
+```
+
+The key is **not written into the TOML** — it's read from `MEGALLM_API_KEY`, which the CLI exports into your shell rc (`~/.zshrc`, `~/.bashrc`, etc.).
+
+### OpenCode — `~/.config/opencode/opencode.json`
+
+Adds `provider.anthropic` pointing at MegaLLM, plus a fallback list of non-Anthropic models. Other providers (e.g. `chutes`, `google`) are preserved:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    // …other providers untouched…
+    "anthropic": {
+      "models": {
+        "gpt-5":      { "id": "gpt-5",      "name": "GPT-5 (Via MegaLLM)" },
+        "gpt-4o":     { "id": "gpt-4o",     "name": "GPT-4o (Via MegaLLM)" },
+        "gpt-4o-mini":{ "id": "gpt-4o-mini","name": "GPT-4o Mini (Via MegaLLM)" }
+      },
+      "options": {
+        "apiKey": "{env:MEGALLM_API_KEY}",
+        "baseURL": "https://ai.megallm.io/v1"
+      }
+    }
+  }
+}
+```
+
+When `MegaLLM` reaches your account, the CLI fetches the **live model list** from `https://ai.megallm.io/models` and writes those instead of the three-model fallback above.
+
+---
+
+## Configuring OpenCode
+
+Two equivalent paths:
+
+```bash
+# A — explicit, single tool
+npx megallm login            # one-time sign-in
+npx megallm link opencode    # writes the provider block above
+
+# B — interactive
+npx megallm                  # pick "Configure / re-configure tools"
+```
+
+Verify:
+
+```bash
+npx megallm doctor           # → "✓ OpenCode configured for MegaLLM"
+```
+
+To remove just the MegaLLM provider from OpenCode (keeps everything else):
+
+```bash
+npx megallm unlink opencode
+```
+
+---
+
+## Profiles
+
+Multiple accounts? Pass `--profile` to any command, or set `MEGALLM_PROFILE`:
+
+```bash
+megallm login --profile work
+megallm login --profile personal
+
+megallm profile list              # ★ marks the active one
+megallm profile use work          # switch
+megallm whoami --profile personal # one-shot override
+```
+
+Profiles live in `~/.megallm/profiles/<name>/`:
+
+```
+~/.megallm/
+├── config.json              # { "current_profile": "work" }
+└── profiles/
+    ├── work/
+    │   ├── auth.json        # chmod 0600 — apiKey, scopes, user, orgId
+    │   └── state.json       # cached orgs list
+    └── personal/
+        ├── auth.json
+        └── state.json
+```
+
+---
+
+## Doctor
+
+`megallm doctor` runs every check the CLI knows about and prints a green/yellow/red report:
+
+- Node 18+
+- `~/.megallm` exists with `0700`, `auth.json` with `0600`
+- Saved key is accepted by the backend (`/oauth/userinfo`)
+- All four scopes present (`api:use`, `profile:read`, `keys:read`, `keys:manage`)
+- Each tool installed, with config that points at MegaLLM
+- Env vars `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, `MEGALLM_API_KEY` are exported
+
+Exits non-zero on any critical failure — wire it into CI to catch drift.
+
+---
+
+## Installation Options
+
+```bash
+# One-shot (recommended)
 npx megallm@latest
 
-# Specific version
-npx megallm@1.0.0
-```
-</details>
-
-<details>
-<summary><b>💻 Global Installation</b></summary>
-
-```bash
-# Install globally
+# Globally
 npm install -g megallm
-
-# Run from anywhere
 megallm
-```
-</details>
 
-<details>
-<summary><b>🪟 Windows PowerShell</b></summary>
-
-```powershell
-# Clear cache if needed
-npm cache clean --force
-
-# Run with explicit version
-npx megallm@latest
-
-# Alternative: Use CMD
-cmd /c "npx megallm"
-```
-</details>
-
-## 🔧 Configuration Details
-
-### Configuration Levels
-
-| Level | Claude Code | Codex/Windsurf | Scope |
-|-------|------------|----------------|-------|
-| **System** | `~/.claude/settings.json` | `~/.codex/config.toml` | All projects |
-| **Project** | `./.claude/settings.json` | `./.codex/config.toml` | Current project only |
-
-### What Gets Configured
-
-<table>
-<tr>
-<th>Claude Code (JSON)</th>
-<th>Codex/Windsurf (TOML)</th>
-</tr>
-<tr>
-<td>
-
-```json
-{
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://ai.megallm.io",
-    "ANTHROPIC_API_KEY": "your-key"
-  },
-  "customApiKeyResponses": {
-    "approved": ["last-20-chars"]
-  }
-}
+# Pin a version
+npx megallm@2.8.0
 ```
 
-</td>
-<td>
-
-```toml
-[api]
-base_url = "https://ai.megallm.io"
-api_key = "your-key"
-provider = "custom"
-
-[auth]
-provider = "custom"
-endpoint = "https://ai.megallm.io"
-```
-
-</td>
-</tr>
-</table>
-
-## 🚦 Setup Flow
-
-### Step 1: Get Your API Key
-
-<div align="center">
-
-#### 🔐 API Key Creation Process
-
-```
-┌──────────────────────────────────────────────────────┐
-│              User runs: npx megallm                  │
-└────────────────────────┬─────────────────────────────┘
-                         ▼
-┌──────────────────────────────────────────────────────┐
-│      Tool asks: "Do you have an API key?"            │
-└──────┬────────────────────────────────────┬──────────┘
-       ▼                                    ▼
-  ┌─────────┐                          ┌─────────┐
-  │ No Key  │                          │ Has Key │
-  └────┬────┘                          └────┬────┘
-       ▼                                    │
-┌──────────────────────────────┐            │
-│    🌐 Browser Opens          │            │
-│       megallm.io             │            │
-└──────────┬───────────────────┘            │
-           ▼                                │
-┌──────────────────────────────┐            │
-│    Create Account            │            │
-│    Generate API Key          │            │
-└──────────┬───────────────────┘            │
-           ▼                                │
-┌──────────────────────────────┐            │
-│    Copy API Key              │            │
-└──────────┬───────────────────┘            │
-           ▼                                ▼
-┌──────────────────────────────────────────────────────┐
-│    📝 Enter API Key in Terminal                      │
-└────────────────────────┬─────────────────────────────┘
-                         ▼
-┌──────────────────────────────────────────────────────┐
-│          ✅ API Key Validated & Saved                │
-└──────────────────────────────────────────────────────┘
-```
-
-**📋 Quick Steps:**
-1. **No API Key?** → Tool opens [megallm.io](https://megallm.io) automatically
-2. **Sign up** → Create your account (free tier available)
-3. **Generate** → Click "Create New API Key"
-4. **Copy** → Copy your key to clipboard
-5. **Paste** → Return to terminal and paste your key
-6. **Done** → Tool validates and saves your configuration
-
-</div>
-
-### Step 2: Choose Your Configuration
-
-| Question | Options | Result |
-|----------|---------|--------|
-| **Which tool?** | Claude Code / Codex / Both | Configures selected tools |
-| **Setup level?** | System / Project | Determines config location |
-| **Confirm?** | Yes / No | Applies configuration |
-
-## 📋 Prerequisites
-
-Before running the setup tool, ensure you have installed:
-
-<table>
-<tr>
-<td align="center">
-
-  ### Claude Code
-
-  [Download](https://claude.ai/code)
-
-  Desktop AI coding assistant
-
-</td>
-<td align="center">
-
-  ### Codex/Windsurf
-
-  [Download](https://openai.com/codex)
-
-  AI-powered code editor
-
-</td>
-</tr>
-</table>
-
-## 🛠️ Advanced Usage
-
-### Environment Variables
-
-```bash
-# Enable debug output
-DEBUG=* npx megallm
-
-# Skip welcome banner
-NO_BANNER=1 npx megallm
-
-# Combine options
-DEBUG=* NO_BANNER=1 npx megallm
-```
-
-### Manual Configuration
-
-If you prefer manual setup, edit these files directly:
-
-<details>
-<summary><b>Claude Code Configuration</b></summary>
-
-Location: `~/.claude/settings.json`
-
-```json
-{
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://ai.megallm.io",
-    "ANTHROPIC_API_KEY": "your-api-key-here"
-  },
-  "customApiKeyResponses": {
-    "approved": ["last-20-chars-of-key"],
-    "rejected": []
-  }
-}
-```
-</details>
-
-<details>
-<summary><b>Codex/Windsurf Configuration</b></summary>
-
-Location: `~/.codex/config.toml`
-
-```toml
-[api]
-base_url = "https://ai.megallm.io"
-api_key = "your-api-key-here"
-provider = "custom"
-
-[auth]
-provider = "custom"
-endpoint = "https://ai.megallm.io"
-api_key = "your-api-key-here"
-```
-</details>
-
-## 🐛 Troubleshooting
-
-<details>
-<summary><b>Tool Not Detected</b></summary>
-
-- Ensure Claude Code or Codex is installed
-- Check configuration directories exist:
-  - Claude: `~/.claude/`
-  - Codex: `~/.codex/`
-- Try restarting your terminal
-</details>
-
-<details>
-<summary><b>Configuration Not Applied</b></summary>
-
-- Restart your terminal/shell
-- For project configs, verify you're in the right directory
-- Check file permissions: `ls -la ~/.claude/` or `~/.codex/`
-</details>
-
-<details>
-<summary><b>API Key Issues</b></summary>
-
-- Verify key is valid at [megallm.io](https://megallm.io)
-- Check for extra spaces or characters
-- Ensure key has proper permissions
-- Try regenerating the key if needed
-</details>
-
-## 📚 Documentation
-
-- 📖 [MegaLLM Documentation](https://docs.megallm.io/)
-- ❓ [Frequently Asked Questions (FAQ)](FAQ.md)
-- 🤖 [Claude Code Docs](https://docs.claude.com/claude-code)
-- 💻 [API Reference](https://docs.megallm.io/api)
-
-## 🤝 Contributing
-
-We welcome contributions! Here's how to get started:
-
-```bash
-# Fork and clone
-git clone https://github.com/yourusername/megallm-npm
-cd megallm-npm
-
-# Install dependencies
-npm install
-
-# Make changes and test
-npm start
-
-# Submit PR
-git push origin feature/your-feature
-```
-
-## 💬 Support
-
-<div align="center">
-
-| Channel | Link |
-|---------|------|
-| 📧 **Email** | [support@megallm.io](mailto:support@megallm.io) |
-| 🐛 **Issues** | [GitHub Issues](https://github.com/Megallm/megallm-npm/issues) |
-| 💬 **Discord** | [Join Community](https://discord.gg/megallm) |
-| 📚 **Docs** | [Documentation](https://docs.megallm.io) |
-
-</div>
-
-## 📄 License
-
-MIT License - see [LICENSE](LICENSE) file for details.
+Requires **Node 18 or newer** (Ink uses ESM).
 
 ---
 
+## Environment Variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `MEGALLM_PROFILE` | Active credential profile | `default` |
+| `MEGALLM_WEB_URL` | Web app URL (OAuth host) | `https://megallm.io` |
+| `MEGALLM_CLI_CLIENT_ID` | OAuth `client_id` for the CLI | `mega_pub_cli` |
+| `DEBUG` | Print stack traces on error | unset |
+
+The CLI exports these into your shell rc when it wires up tools:
+
+| Variable | Read by |
+|---|---|
+| `ANTHROPIC_BASE_URL` | Claude Code |
+| `ANTHROPIC_API_KEY` | Claude Code |
+| `MEGALLM_API_KEY` | Codex, OpenCode |
+
+After install, `source ~/.zshrc` (or open a new shell) to pick them up.
+
+---
+
+## Troubleshooting
+
+<details>
+<summary><b>"Saved key is no longer valid"</b></summary>
+
+The server rejected the bearer key. Either you revoked it from the dashboard, or the OAuth app is missing scopes. Re-login:
+
+```bash
+megallm logout
+megallm login
+```
+
+Make sure your OAuth app at `/dashboard/developers` has all four scopes ticked: `api:use`, `profile:read`, `keys:read`, `keys:manage`.
+</details>
+
+<details>
+<summary><b>Tool detected but doctor says "not configured for MegaLLM"</b></summary>
+
+The tool's config file exists but doesn't have the MegaLLM block. Wire it:
+
+```bash
+megallm link claude
+megallm link codex
+megallm link opencode
+```
+</details>
+
+<details>
+<summary><b>"MEGALLM_API_KEY environment variable not set" warning</b></summary>
+
+Codex and OpenCode read the key from the env, not the config file. The CLI writes the export to your shell rc; you just need to reload:
+
+```bash
+source ~/.zshrc       # or ~/.bashrc
+```
+
+Or open a new terminal.
+</details>
+
+<details>
+<summary><b>I want to keep my existing Codex / OpenCode setup</b></summary>
+
+You can. The configurators **merge** instead of overwriting — your other providers, models, plugins, and tools stay intact. To verify, diff before/after:
+
+```bash
+cp ~/.config/opencode/opencode.json /tmp/before.json
+megallm link opencode
+diff /tmp/before.json ~/.config/opencode/opencode.json
+```
+</details>
+
+<details>
+<summary><b>Switch organizations</b></summary>
+
+```bash
+megallm switch-org           # interactive picker
+megallm switch-org org_abc   # direct
+```
+
+Switching mints a fresh per-org API key, replaces the saved key, and rewrites all linked tools to use it.
+</details>
+
+---
+
+## Documentation
+
+- [MegaLLM Docs](https://docs.megallm.io/)
+- [FAQ](FAQ.md)
+- [Claude Code](https://docs.claude.com/claude-code)
+- [OpenCode](https://opencode.ai)
+
+---
+
+## Support
+
+| | |
+|---|---|
+| Email | [support@megallm.io](mailto:support@megallm.io) |
+| Issues | [GitHub Issues](https://github.com/Megallm/megallm-npm/issues) |
+| Discord | [Join Community](https://discord.gg/megallm) |
+| Docs | [docs.megallm.io](https://docs.megallm.io) |
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+
 <div align="center">
 
-  **Built with ❤️ by the [MegaLLM](https://megallm.io) Team**
-
-  ⭐ Star us on [GitHub](https://github.com/Megallm/megallm-npm)
+  Built by the [MegaLLM](https://megallm.io) team.
+  Star us on [GitHub](https://github.com/Megallm/megallm-npm).
 
 </div>

--- a/bin/megallm.js
+++ b/bin/megallm.js
@@ -46,6 +46,7 @@ Usage:
   megallm whoami [--profile p]   Show the identity behind the saved key
   megallm status [--profile p]   Plain-text snapshot of identity + tools
   megallm doctor [--profile p]   Run diagnostic checks on creds, tools, env
+  megallm doctor fix             Auto-repair tool configs that hold a stale key
   megallm orgs   [--profile p]   List organizations you can switch into
   megallm switch-org [<id>]      Switch to an org and mint a fresh per-org key
   megallm keys list [--org id]   List API keys in the active (or given) org
@@ -114,6 +115,11 @@ function dieOnError(promise) {
       return dieOnError(runStatus({ profile }));
     }
     case 'doctor': {
+      const action = argv[1];
+      if (action === 'fix') {
+        const { runDoctorFix } = await import('../src/commands/doctor.js');
+        return dieOnError(runDoctorFix({ profile }));
+      }
       const { runDoctor } = await import('../src/commands/doctor.js');
       return dieOnError(runDoctor({ profile }));
     }

--- a/bin/megallm.js
+++ b/bin/megallm.js
@@ -28,6 +28,7 @@ function takeFlag(args, name, hasValue) {
 }
 
 const profile = takeFlag(argv, '--profile', true) || takeFlag(argv, '-p', true);
+const noBrowser = !!takeFlag(argv, '--no-browser');
 const wantsHelp = takeFlag(argv, '--help') || takeFlag(argv, '-h');
 const wantsVersion = takeFlag(argv, '--version') || takeFlag(argv, '-v');
 
@@ -39,7 +40,8 @@ MegaLLM CLI — sign in once, configure Claude Code / Codex / OpenCode.
 Usage:
   megallm                        Open the interactive hub (auto-detects TTY)
   megallm setup                  Run the full setup wizard
-  megallm login [--profile p]    Sign in via the browser (OAuth device flow)
+  megallm login [--profile p]    Sign in via the browser (OAuth, loopback redirect)
+                  [--no-browser]    Force the device-code fallback (headless / SSH)
   megallm logout [--profile p]   Revoke the saved key and clear local creds
   megallm whoami [--profile p]   Show the identity behind the saved key
   megallm status [--profile p]   Plain-text snapshot of identity + tools
@@ -141,7 +143,7 @@ function dieOnError(promise) {
     }
     case 'login': {
       const { runLogin } = await import('../src/commands/login.js');
-      return dieOnError(runLogin({ profile, setCurrent: !!profile }));
+      return dieOnError(runLogin({ profile, setCurrent: !!profile, noBrowser }));
     }
     case 'logout': {
       const { runLogout } = await import('../src/commands/logout.js');

--- a/bin/megallm.js
+++ b/bin/megallm.js
@@ -1,13 +1,190 @@
 #!/usr/bin/env node
-import('../src/cli.js').then(module => {
-  const main = module.default;
-  if (typeof main === 'function') {
-    main().catch(error => {
-      console.error('Error:', error.message);
-      process.exit(1);
-    });
+// MegaLLM CLI entry point. Routes subcommands to handlers and falls back to
+// the interactive setup wizard when invoked with no args (preserves the
+// classic `npx megallm@latest` experience).
+
+const argv = process.argv.slice(2);
+
+// --- tiny flag parser -------------------------------------------------------
+function takeFlag(args, name, hasValue) {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === name) {
+      if (hasValue) {
+        const v = args[i + 1];
+        args.splice(i, 2);
+        return v;
+      }
+      args.splice(i, 1);
+      return true;
+    }
+    if (hasValue && a.startsWith(name + '=')) {
+      const v = a.slice(name.length + 1);
+      args.splice(i, 1);
+      return v;
+    }
   }
-}).catch(error => {
-  console.error('Failed to start MegaLLM CLI:', error.message);
-  process.exit(1);
-});
+  return undefined;
+}
+
+const profile = takeFlag(argv, '--profile', true) || takeFlag(argv, '-p', true);
+const wantsHelp = takeFlag(argv, '--help') || takeFlag(argv, '-h');
+const wantsVersion = takeFlag(argv, '--version') || takeFlag(argv, '-v');
+
+const sub = argv[0];
+
+const HELP = `
+MegaLLM CLI — sign in once, configure Claude Code / Codex / OpenCode.
+
+Usage:
+  megallm                        Open the interactive hub (auto-detects TTY)
+  megallm setup                  Run the full setup wizard
+  megallm login [--profile p]    Sign in via the browser (OAuth device flow)
+  megallm logout [--profile p]   Revoke the saved key and clear local creds
+  megallm whoami [--profile p]   Show the identity behind the saved key
+  megallm status [--profile p]   Plain-text snapshot of identity + tools
+  megallm doctor [--profile p]   Run diagnostic checks on creds, tools, env
+  megallm orgs   [--profile p]   List organizations you can switch into
+  megallm switch-org [<id>]      Switch to an org and mint a fresh per-org key
+  megallm keys list [--org id]   List API keys in the active (or given) org
+  megallm keys revoke <key_id>   Revoke a key by its id
+
+  megallm link   <tool>          Wire up one tool (claude | codex | opencode)
+  megallm unlink <tool>          Remove MegaLLM keys from one tool
+
+  megallm profile list           List saved credential profiles
+  megallm profile use <name>     Make <name> the active profile
+  megallm profile rm  <name>     Delete a saved profile
+
+Global flags:
+  --profile <name>  / -p <name>  Use a named credential profile  (env: MEGALLM_PROFILE)
+  --help    / -h                 Show this help
+  --version / -v                 Show the CLI version
+`;
+
+async function showVersion() {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const here = dirname(fileURLToPath(import.meta.url));
+  const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf8'));
+  console.log(`megallm ${pkg.version}`);
+}
+
+function dieOnError(promise) {
+  return promise.catch(err => {
+    if (err && err.message && err.message.includes('User force closed')) {
+      console.log('\n👋 Cancelled.');
+      process.exit(0);
+    }
+    console.error(`\nError: ${err.message || err}`);
+    if (process.env.DEBUG) console.error(err.stack);
+    process.exit(1);
+  });
+}
+
+(async () => {
+  if (wantsVersion) return showVersion();
+  if (wantsHelp && !sub) { console.log(HELP); return; }
+
+  switch (sub) {
+    case undefined: {
+      // No subcommand → show the Ink hub when we're attached to a TTY,
+      // otherwise print help so scripted invocations stay deterministic.
+      if (process.stdout.isTTY && process.stdin.isTTY) {
+        const { runHub } = await import('../src/commands/hub.js');
+        return dieOnError(runHub({ profile }));
+      }
+      console.log(HELP);
+      return;
+    }
+    case 'hub': {
+      const { runHub } = await import('../src/commands/hub.js');
+      return dieOnError(runHub({ profile }));
+    }
+    case 'setup':
+    case 'wizard': {
+      const { default: main } = await import('../src/cli.js');
+      return dieOnError(main());
+    }
+    case 'status': {
+      const { runStatus } = await import('../src/commands/status.js');
+      return dieOnError(runStatus({ profile }));
+    }
+    case 'doctor': {
+      const { runDoctor } = await import('../src/commands/doctor.js');
+      return dieOnError(runDoctor({ profile }));
+    }
+    case 'link': {
+      const tool = argv[1];
+      const { runLink } = await import('../src/commands/link.js');
+      return dieOnError(runLink({ profile, tool }));
+    }
+    case 'unlink': {
+      const tool = argv[1];
+      const { runUnlink } = await import('../src/commands/link.js');
+      return dieOnError(runUnlink({ tool }));
+    }
+    case 'profile': {
+      const action = argv[1];
+      const arg = argv[2];
+      const mod = await import('../src/commands/profile.js');
+      if (!action || action === 'list')   return dieOnError(mod.runProfileList());
+      if (action === 'use')               return dieOnError(mod.runProfileUse({ name: arg }));
+      if (action === 'rm' || action === 'remove' || action === 'delete') {
+        return dieOnError(mod.runProfileRm({ name: arg }));
+      }
+      console.error(`Unknown profile action: ${action}`);
+      console.log(HELP);
+      process.exit(1);
+      break;
+    }
+    case 'login': {
+      const { runLogin } = await import('../src/commands/login.js');
+      return dieOnError(runLogin({ profile, setCurrent: !!profile }));
+    }
+    case 'logout': {
+      const { runLogout } = await import('../src/commands/logout.js');
+      return dieOnError(runLogout({ profile }));
+    }
+    case 'whoami': {
+      const { runWhoami } = await import('../src/commands/whoami.js');
+      return dieOnError(runWhoami({ profile }));
+    }
+    case 'orgs': {
+      const { runOrgs } = await import('../src/commands/orgs.js');
+      return dieOnError(runOrgs({ profile }));
+    }
+    case 'switch-org': {
+      const orgId = argv[1];
+      const { runSwitchOrg } = await import('../src/commands/switch-org.js');
+      return dieOnError(runSwitchOrg({ profile, orgId }));
+    }
+    case 'keys': {
+      const action = argv[1];
+      if (action === 'list' || action === undefined) {
+        const orgId = takeFlag(argv, '--org', true);
+        const { runKeysList } = await import('../src/commands/keys.js');
+        return dieOnError(runKeysList({ profile, orgId }));
+      }
+      if (action === 'revoke') {
+        const keyId = argv[2];
+        const { runKeysRevoke } = await import('../src/commands/keys.js');
+        return dieOnError(runKeysRevoke({ profile, keyId }));
+      }
+      console.error(`Unknown keys action: ${action}`);
+      console.log(HELP);
+      process.exit(1);
+      break;
+    }
+    case 'help': {
+      console.log(HELP);
+      return;
+    }
+    default: {
+      console.error(`Unknown command: ${sub}`);
+      console.log(HELP);
+      process.exit(1);
+    }
+  }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,70 @@
 {
   "name": "megallm",
-  "version": "2.5.9",
+  "version": "2.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "megallm",
-      "version": "2.5.9",
+      "version": "2.8.1",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "@inquirer/prompts": "^3.3.0",
+        "cfonts": "^3.3.1",
         "chalk": "^5.3.0",
-        "figlet": "^1.7.0",
         "fs-extra": "^11.2.0",
-        "ora": "^7.0.1"
+        "gradient-string": "^3.0.0",
+        "htm": "^3.1.1",
+        "ink": "^5.2.1",
+        "ink-select-input": "^6.2.0",
+        "ink-spinner": "^5.0.0",
+        "ora": "^7.0.1",
+        "react": "^18.3.1",
+        "unicode-animations": "^1.0.3"
       },
       "bin": {
         "megallm": "bin/megallm.js"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+      "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@iarna/toml": {
@@ -367,6 +411,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/tinycolor2": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
+      "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
+      "license": "MIT"
+    },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
@@ -410,6 +460,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/base64-js": {
@@ -467,6 +529,37 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/cfonts": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/cfonts/-/cfonts-3.3.1.tgz",
+      "integrity": "sha512-ZGEmN3W9mViWEDjsuPo4nK4h39sfh6YtoneFYp9WLPI/rw8BaSSrfQC6jkrGW3JMvV3ZnExJB/AEqXc/nHYxkw==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "supports-color": "^8",
+        "window-size": "^1"
+      },
+      "bin": {
+        "cfonts": "bin/index.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cfonts/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -484,6 +577,18 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "license": "MIT"
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "4.0.0",
@@ -512,6 +617,106 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -519,6 +724,18 @@
       "license": "ISC",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/color-convert": {
@@ -539,13 +756,25 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/commander": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eastasianwidth": {
@@ -559,6 +788,28 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -581,21 +832,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/figlet": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.9.3.tgz",
-      "integrity": "sha512-majPgOpVtrZN1iyNGbsUP6bOtZ6eaJgg5HHh0vFvm5DJhh8dc+FJpOC4GABvMZ/A7XHAJUuJujhgUY/2jPWgMA==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^14.0.0"
-      },
-      "bin": {
-        "figlet": "bin/index.js"
-      },
-      "engines": {
-        "node": ">= 17.0.0"
       }
     },
     "node_modules/figures": {
@@ -627,11 +863,45 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/gradient-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gradient-string/-/gradient-string-3.0.0.tgz",
+      "integrity": "sha512-frdKI4Qi8Ihp4C6wZNB565de/THpIaw3DjP5ku87M+N9rNSGmPTjfkq61SdRXB7eCaL8O1hkKDvf6CDMtOzIAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "tinygradient": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -641,6 +911,24 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -674,11 +962,280 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ink": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-5.2.1.tgz",
+      "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.1.3",
+        "ansi-escapes": "^7.0.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^4.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.22.0",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^1.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.29.0",
+        "scheduler": "^0.23.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.27.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
+        "react-devtools-core": "^4.19.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-select-input": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ink-select-input/-/ink-select-input-6.2.0.tgz",
+      "integrity": "sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "figures": "^6.1.0",
+        "to-rotated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink-select-input/node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink-select-input/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink-spinner": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
+      "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-spinners": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "peerDependencies": {
+        "ink": ">=4.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/ink/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/is-accessor-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.2.tgz",
+      "integrity": "sha512-AIbwAcazqP3R65dGvqk1V+a+vE5Fg1yu/ZKMOiBWSUIXXiwQkYmXQcVa2O0nh0tSDKDFKxG2mY7dB1Sr4hEP1g==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
+    "node_modules/is-data-descriptor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
+      "integrity": "sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-descriptor": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.4.tgz",
+      "integrity": "sha512-bv5z95W0dDtLfKwDfkTNxaRxmISBD3eQBKJeVxv2AQ7MjuUnDNG7cIQqvFtMOUYhsILWHhMayWdoGqNqYYYjww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.2",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -687,6 +1244,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -701,6 +1273,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
@@ -713,6 +1297,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
@@ -723,6 +1313,18 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/log-symbols": {
@@ -739,6 +1341,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/mimic-fn": {
@@ -833,6 +1447,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -904,6 +1555,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -914,6 +1574,70 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/stdin-discarder": {
@@ -1008,6 +1732,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
+    "node_modules/tinygradient": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-1.1.5.tgz",
+      "integrity": "sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/tinycolor2": "^1.4.0",
+        "tinycolor2": "^1.0.0"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -1018,6 +1758,18 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/to-rotated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-rotated/-/to-rotated-1.0.0.tgz",
+      "integrity": "sha512-KsEID8AfgUy+pxVRLsWp0VzCa69wxzUDZnzGbyIST/bcgcrMvTYoFBX/QORH4YApoD89EDuUovx4BTdpOn319Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-fest": {
@@ -1038,6 +1790,19 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unicode-animations": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-animations/-/unicode-animations-1.0.3.tgz",
+      "integrity": "sha512-+klB2oWwcYZjYWhwP4Pr8UZffWDFVx6jKeIahE6z0QYyM2dwDeDPyn5nevCYbyotxvtT9lh21cVURO1RX0+YMg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-animations": "^1.0.1"
+      },
+      "bin": {
+        "unicode-animations": "scripts/demo.cjs"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -1052,6 +1817,81 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/window-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-1.1.1.tgz",
+      "integrity": "sha512-5D/9vujkmVQ7pSmc0SCBmHXbkv6eaHwXEx65MywhmUMsI8sGqJ972APq1lotfcwMKPFLuCFfL8xGHLIp7jaBmA==",
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "is-number": "^3.0.0"
+      },
+      "bin": {
+        "window-size": "cli.js"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -1086,6 +1926,33 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "megallm",
-  "version": "2.5.9",
-  "description": "Setup tool for configuring Claude Code and Codex to use MegaLLM AI service",
+  "version": "2.8.1",
+  "description": "Sign in once, configure Claude Code / Codex / OpenCode. Interactive Ink-based hub with OAuth device flow, named profiles, and per-org API keys.",
   "main": "src/cli.js",
   "type": "module",
   "bin": {
@@ -21,9 +21,11 @@
     "megallm",
     "claude",
     "codex",
+    "opencode",
     "ai",
     "setup",
     "cli",
+    "oauth",
     "configuration"
   ],
   "author": "MegaLLM",
@@ -31,10 +33,17 @@
   "dependencies": {
     "@iarna/toml": "^2.2.5",
     "@inquirer/prompts": "^3.3.0",
+    "cfonts": "^3.3.1",
     "chalk": "^5.3.0",
-    "figlet": "^1.7.0",
     "fs-extra": "^11.2.0",
-    "ora": "^7.0.1"
+    "gradient-string": "^3.0.0",
+    "htm": "^3.1.1",
+    "ink": "^5.2.1",
+    "ink-select-input": "^6.2.0",
+    "ink-spinner": "^5.0.0",
+    "ora": "^7.0.1",
+    "react": "^18.3.1",
+    "unicode-animations": "^1.0.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/auth/api.js
+++ b/src/auth/api.js
@@ -1,0 +1,68 @@
+// Thin client over the bearer-key-authed endpoints in megallm-web-v2.
+// Each function takes the user's sk-mega API key and returns parsed JSON.
+import { MEGALLM_WEB_URL } from '../constants.js';
+
+const USER_AGENT = `megallm-cli/${process.env.npm_package_version || '0.0.0'} (${process.platform})`;
+
+async function callApi(apiKey, method, urlPath, { query, body } = {}) {
+  const url = new URL(`${MEGALLM_WEB_URL}${urlPath}`);
+  if (query) {
+    for (const [k, v] of Object.entries(query)) {
+      if (v != null) url.searchParams.set(k, String(v));
+    }
+  }
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    'User-Agent': USER_AGENT,
+  };
+  if (body !== undefined) headers['Content-Type'] = 'application/json';
+  const res = await fetch(url.toString(), {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg = json.message || json.error || `HTTP ${res.status}`;
+    const err = new Error(msg);
+    err.status = res.status;
+    err.payload = json;
+    throw err;
+  }
+  return json;
+}
+
+/** Orgs the authenticated user belongs to: [{ org_id, org_name, role? }] */
+export async function listOrgs(apiKey) {
+  const json = await callApi(apiKey, 'GET', '/api/oauth/orgs');
+  return Array.isArray(json?.data) ? json.data : [];
+}
+
+/** API keys for a given org: { keys: [...] } (raw backend shape preserved). */
+export async function listKeys(apiKey, orgId) {
+  const json = await callApi(apiKey, 'GET', '/api/v1/keys', { query: { org: orgId } });
+  return json?.data || json;
+}
+
+/**
+ * Create a new API key under `orgId`. Returns the freshly-minted key.
+ * Backend response is normalized to { api_key, api_key_id, key_prefix, ...rest }.
+ */
+export async function createKey(apiKey, { orgId, name, services, limits, expiresAt } = {}) {
+  const json = await callApi(apiKey, 'POST', '/api/v1/keys', {
+    body: {
+      api_key_name: name,
+      org_id: orgId,
+      services,
+      limits,
+      expires_at: expiresAt,
+    },
+  });
+  // Backend wraps payload in { success, data: {...} }; web-v2 forwards as-is.
+  return json?.data || json;
+}
+
+/** Revoke an API key by its backend `api_key_id`. */
+export async function revokeKey(apiKey, keyId) {
+  await callApi(apiKey, 'DELETE', `/api/v1/keys/${encodeURIComponent(keyId)}`);
+}

--- a/src/auth/keys.js
+++ b/src/auth/keys.js
@@ -1,0 +1,84 @@
+// Per-org key resolution shared between `megallm switch-org` and the
+// `megallm setup` / `npx megallm` wizard.
+//
+// Behaviour:
+//   1. If the local `auth.keysByOrg[orgId]` cache has an entry, ask the
+//      backend if that key is still alive (matches by api_key_id, falling
+//      back to key_prefix).
+//   2. If alive → reuse it.
+//   3. Otherwise → mint a fresh one via /api/v1/keys.
+//
+// Returns { apiKey, apiKeyId, keyPrefix, reused, keysByOrg } where
+// `keysByOrg` is the updated cache the caller should persist.
+
+import { listKeys, createKey } from './api.js';
+
+async function verifyKeyAlive(authApiKey, orgId, cached) {
+  try {
+    const payload = await listKeys(authApiKey, orgId);
+    const keys = payload?.keys || payload?.data || payload || [];
+    if (!Array.isArray(keys) || keys.length === 0) return false;
+    if (cached.api_key_id && keys.some(k => (k.api_key_id || k.id) === cached.api_key_id)) return true;
+    if (cached.key_prefix && keys.some(k => (k.key_prefix || k.prefix) === cached.key_prefix)) return true;
+    return false;
+  } catch {
+    return null; // network/auth failure — caller decides
+  }
+}
+
+/**
+ * @param {object} args
+ * @param {object} args.auth     Current auth record (apiKey, orgId, keysByOrg, …)
+ * @param {object} args.org      Target org { org_id, org_name }
+ * @param {(msg: string) => void} [args.onProgress] Optional UI hook.
+ * @returns {Promise<{ apiKey: string, apiKeyId: string|null, keyPrefix: string, reused: boolean, keysByOrg: object }>}
+ */
+export async function resolveKeyForOrg({ auth, org, onProgress }) {
+  const cached = auth.keysByOrg?.[org.org_id];
+  let apiKey, apiKeyId = null, keyPrefix, reused = false;
+
+  if (cached?.api_key) {
+    onProgress?.(`Checking saved key for ${org.org_name}…`);
+    const alive = await verifyKeyAlive(auth.apiKey, org.org_id, cached);
+    if (alive === true) {
+      apiKey    = cached.api_key;
+      apiKeyId  = cached.api_key_id || null;
+      keyPrefix = cached.key_prefix || apiKey.slice(0, 16);
+      reused = true;
+    }
+  }
+
+  if (!apiKey) {
+    onProgress?.(`Creating a new API key for ${org.org_name}…`);
+    const minted = await createKey(auth.apiKey, {
+      orgId: org.org_id,
+      name: `MegaLLM CLI · ${new Date().toISOString().slice(0, 10)}`,
+    });
+    apiKey    = minted.api_key || minted.apiKey;
+    apiKeyId  = minted.api_key_id || minted.apiKeyId || null;
+    keyPrefix = minted.key_prefix || apiKey?.slice(0, 16);
+    if (!apiKey) throw new Error('Server did not return an API key.');
+  }
+
+  // Lazy-stash the previous active org's key so users upgrading from older
+  // CLIs get their existing key cached on the very first switch.
+  const keysByOrg = { ...(auth.keysByOrg || {}) };
+  if (auth.orgId && auth.apiKey && !keysByOrg[auth.orgId]) {
+    keysByOrg[auth.orgId] = {
+      api_key:    auth.apiKey,
+      api_key_id: auth.apiKeyId || null,
+      key_prefix: auth.keyPrefix || auth.apiKey.slice(0, 16),
+      org_name:   auth.orgName || null,
+      saved_at:   new Date().toISOString(),
+    };
+  }
+  keysByOrg[org.org_id] = {
+    api_key:    apiKey,
+    api_key_id: apiKeyId,
+    key_prefix: keyPrefix,
+    org_name:   org.org_name,
+    saved_at:   new Date().toISOString(),
+  };
+
+  return { apiKey, apiKeyId, keyPrefix, reused, keysByOrg };
+}

--- a/src/auth/login.js
+++ b/src/auth/login.js
@@ -1,0 +1,104 @@
+// High-level login orchestrator: device flow → token → identity → org pick → save.
+// Used by both `megallm login` and the interactive setup wizard.
+import chalk from 'chalk';
+import { brailleOra as ora } from '../utils/spinner.js';
+import { startDeviceFlow, pollForToken, fetchUserInfo, openInBrowser } from './oauth.js';
+import { listOrgs } from './api.js';
+import { writeAuth, writeState, ensureMegallmHome } from './store.js';
+import { OAUTH_CLIENT_ID, OAUTH_SCOPES, DEFAULT_PROFILE } from '../constants.js';
+
+/**
+ * Run the full device-flow login. Returns the saved auth record on success.
+ *
+ * @param {{ profile?: string, openBrowser?: boolean }} opts
+ */
+export async function loginWithBrowser({ profile = DEFAULT_PROFILE, openBrowser = true } = {}) {
+  await ensureMegallmHome();
+
+  // 1. Start the device flow.
+  const startSpinner = ora('Requesting device code…').start();
+  let device;
+  try {
+    device = await startDeviceFlow({
+      clientId: OAUTH_CLIENT_ID,
+      scopes: OAUTH_SCOPES,
+    });
+    startSpinner.succeed('Device code received');
+  } catch (err) {
+    startSpinner.fail(err.message);
+    throw err;
+  }
+
+  const url = device.verification_uri_complete || device.verification_uri;
+
+  // 2. Show the code prominently and try to open the browser.
+  console.log('');
+  console.log(chalk.cyan('  ┌──────────────────────────────────────────┐'));
+  console.log(chalk.cyan('  │              Sign in to MegaLLM           │'));
+  console.log(chalk.cyan('  ├──────────────────────────────────────────┤'));
+  console.log(chalk.cyan('  │ Open this URL in your browser:            │'));
+  console.log(chalk.white('  │   ' + (device.verification_uri || '').padEnd(38) + ' │'));
+  console.log(chalk.cyan('  │                                          │'));
+  console.log(chalk.cyan('  │ And enter this code:                     │'));
+  console.log(chalk.yellow.bold('  │   ' + (device.user_code || '').padEnd(38) + ' │'));
+  console.log(chalk.cyan('  └──────────────────────────────────────────┘'));
+  console.log('');
+
+  if (openBrowser && url) {
+    console.log(chalk.gray(`Opening ${url} …`));
+    openInBrowser(url);
+  }
+
+  // 3. Poll for the key.
+  const pollSpinner = ora('Waiting for authorization…').start();
+  let token;
+  try {
+    token = await pollForToken({
+      device_code: device.device_code,
+      interval: device.interval || 5,
+      expires_in: device.expires_in || 900,
+      onTick: ({ secondsLeft }) => {
+        pollSpinner.text = `Waiting for authorization… (${secondsLeft}s left)`;
+      },
+    });
+    pollSpinner.succeed('Authorized');
+  } catch (err) {
+    pollSpinner.fail(err.message);
+    throw err;
+  }
+
+  const apiKey = token.api_key;
+  if (!apiKey) throw new Error('Login response did not contain an API key');
+
+  // 4. Fetch identity (best-effort) and the list of orgs the user belongs to.
+  let user = null;
+  try { user = await fetchUserInfo(apiKey); } catch { /* tolerate */ }
+
+  let orgs = [];
+  try { orgs = await listOrgs(apiKey); } catch { /* tolerate */ }
+
+  // The /activate page already let the user pick the org for THIS key.
+  // We don't know the chosen org_id from the token response, so we use the
+  // first matching org (typically the user's default) for display, and store
+  // the full list so `megallm orgs` can show it without an extra round trip.
+  const activeOrg = orgs[0] || null;
+
+  // 5. Persist.
+  const record = {
+    apiKey,
+    keyPrefix: token.key_prefix || apiKey.slice(0, 16),
+    scopes: token.scopes || OAUTH_SCOPES,
+    user: user || null,
+    orgId: activeOrg?.org_id || null,
+    orgName: activeOrg?.org_name || null,
+    clientId: OAUTH_CLIENT_ID,
+  };
+  await writeAuth(record, profile);
+  await writeState({
+    current_org_id: record.orgId,
+    current_org_name: record.orgName,
+    orgs,
+  }, profile);
+
+  return record;
+}

--- a/src/auth/oauth.js
+++ b/src/auth/oauth.js
@@ -1,6 +1,8 @@
 // OAuth 2.0 device authorization grant (RFC 8628) client for the MegaLLM web app.
 // Endpoints documented at <megallm.io>/dashboard/developers/docs.
 import { exec } from 'child_process';
+import http from 'http';
+import crypto from 'crypto';
 import {
   MEGALLM_WEB_URL,
   OAUTH_CLIENT_ID,
@@ -11,6 +13,7 @@ const DEVICE_CODE_ENDPOINT = `${MEGALLM_WEB_URL}/api/oauth/device/code`;
 const TOKEN_ENDPOINT = `${MEGALLM_WEB_URL}/api/oauth/token`;
 const USERINFO_ENDPOINT = `${MEGALLM_WEB_URL}/api/oauth/userinfo`;
 const REVOKE_ENDPOINT = `${MEGALLM_WEB_URL}/api/oauth/revoke`;
+const AUTHORIZE_ENDPOINT = `${MEGALLM_WEB_URL}/oauth/authorize`;
 
 const USER_AGENT = `megallm-cli/${process.env.npm_package_version || '0.0.0'} (${process.platform})`;
 
@@ -182,4 +185,233 @@ function sleep(ms, signal) {
       }, { once: true });
     }
   });
+}
+
+// ── Authorization Code + PKCE via loopback redirect (RFC 8252 §7.3) ─────────
+//
+// Preferred login flow when a desktop browser is reachable. The CLI binds an
+// ephemeral HTTP server on 127.0.0.1, opens the consent screen with a
+// `redirect_uri` pointing at it, and exchanges the resulting auth code for
+// an sk-mega key — no polling, instant handoff.
+
+const PKCE_VERIFIER_BYTES = 32;       // → 43-char base64url string
+const CALLBACK_PATH = '/cb';
+const DEFAULT_LOOPBACK_TIMEOUT_MS = 5 * 60_000;
+
+function base64url(buf) {
+  return buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function generatePkcePair() {
+  const verifier = base64url(crypto.randomBytes(PKCE_VERIFIER_BYTES));
+  const challenge = base64url(
+    crypto.createHash('sha256').update(verifier).digest(),
+  );
+  return { verifier, challenge };
+}
+
+const SUCCESS_HTML = `<!doctype html><meta charset="utf-8"><title>MegaLLM CLI</title>
+<style>body{font:15px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;background:#0a0a0a;color:#e5e5e5;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}.card{max-width:420px;text-align:center;padding:32px;border:1px solid #1f1f1f;border-radius:14px;background:#111}.ok{color:#4ade80;font-size:48px;margin-bottom:8px}h1{margin:0 0 8px;font-size:18px}p{margin:0;color:#a3a3a3;font-size:13px}</style>
+<div class="card"><div class="ok">✓</div><h1>You're signed in.</h1><p>Return to your terminal — you can close this tab.</p></div>`;
+
+const ERROR_HTML = (msg) => `<!doctype html><meta charset="utf-8"><title>MegaLLM CLI</title>
+<style>body{font:15px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;background:#0a0a0a;color:#e5e5e5;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}.card{max-width:420px;text-align:center;padding:32px;border:1px solid #1f1f1f;border-radius:14px;background:#111}.bad{color:#f87171;font-size:48px;margin-bottom:8px}h1{margin:0 0 8px;font-size:18px}p{margin:0;color:#a3a3a3;font-size:13px}code{color:#e5e5e5}</style>
+<div class="card"><div class="bad">✕</div><h1>Login failed</h1><p><code>${msg}</code></p><p style="margin-top:12px">You can close this tab and try again from the terminal.</p></div>`;
+
+/**
+ * Runs the full authorization-code + PKCE login flow over a loopback redirect.
+ *
+ * @param {{
+ *   clientId?: string,
+ *   scopes?: string[],
+ *   timeoutMs?: number,
+ *   signal?: AbortSignal,
+ *   onAuthorizeUrl?: (url: string) => void,   // called once with the URL the
+ *                                              // CLI is about to open in a
+ *                                              // browser. Use this to print
+ *                                              // the URL for the user.
+ *   openBrowser?: boolean,                    // default true
+ * }} opts
+ * @returns {Promise<{ api_key: string, token_type: string, scopes: string[],
+ *                     key_prefix: string }>}
+ */
+export async function loopbackLogin({
+  clientId = OAUTH_CLIENT_ID,
+  scopes = OAUTH_SCOPES,
+  timeoutMs = DEFAULT_LOOPBACK_TIMEOUT_MS,
+  signal,
+  onAuthorizeUrl,
+  openBrowser = true,
+} = {}) {
+  if (signal?.aborted) throw new Error('Login cancelled');
+
+  const { verifier, challenge } = generatePkcePair();
+  const state = base64url(crypto.randomBytes(16));
+
+  // 1. Stand up the loopback callback server before we open the browser, so
+  //    the redirect can never beat us.
+  const { server, port, callback } = await startLoopbackServer({
+    state,
+    timeoutMs,
+    signal,
+  });
+  const redirectUri = `http://127.0.0.1:${port}${CALLBACK_PATH}`;
+
+  // 2. Open the consent screen.
+  const authorizeUrl = buildAuthorizeUrl({
+    clientId,
+    scopes,
+    redirectUri,
+    state,
+    challenge,
+  });
+  onAuthorizeUrl?.(authorizeUrl);
+  if (openBrowser) openInBrowser(authorizeUrl);
+
+  // 3. Wait for the redirect → grab the auth code.
+  let code;
+  try {
+    code = await callback;
+  } finally {
+    server.close();
+  }
+
+  // 4. Exchange the code for an sk-mega key.
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri,
+    client_id: clientId,
+    code_verifier: verifier,
+  });
+  const res = await fetch(TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': USER_AGENT,
+    },
+    body: body.toString(),
+    signal,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg = json.error_description || json.error || `HTTP ${res.status}`;
+    throw new Error(`Could not exchange auth code: ${msg}`);
+  }
+  return json;
+}
+
+function buildAuthorizeUrl({ clientId, scopes, redirectUri, state, challenge }) {
+  const qs = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: scopes.join(' '),
+    state,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  });
+  return `${AUTHORIZE_ENDPOINT}?${qs.toString()}`;
+}
+
+/**
+ * Start an HTTP server on 127.0.0.1:0 that resolves with the auth code on
+ * the first matching `/cb?code=...&state=...` hit. Rejects on
+ * `?error=...`, on state mismatch, on timeout, or on signal abort.
+ */
+function startLoopbackServer({ state, timeoutMs, signal }) {
+  return new Promise((resolveOuter, rejectOuter) => {
+    let timer;
+    let onAbort;
+    const callback = new Promise((resolve, reject) => {
+      const server = http.createServer((req, res) => {
+        // Only handle the callback path; any other URL is a stray request.
+        const u = new URL(req.url || '', 'http://127.0.0.1');
+        if (u.pathname !== CALLBACK_PATH) {
+          res.statusCode = 404;
+          res.end();
+          return;
+        }
+        const params = u.searchParams;
+        const gotState = params.get('state');
+        const gotCode = params.get('code');
+        const gotError = params.get('error');
+
+        if (gotError) {
+          const desc = params.get('error_description') || gotError;
+          res.statusCode = 400;
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.end(ERROR_HTML(escapeHtml(desc)));
+          reject(new Error(`Authorization failed: ${desc}`));
+          return;
+        }
+        if (!gotCode) {
+          res.statusCode = 400;
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.end(ERROR_HTML('Missing authorization code'));
+          reject(new Error('Authorization callback missing `code`'));
+          return;
+        }
+        if (gotState !== state) {
+          res.statusCode = 400;
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.end(ERROR_HTML('State mismatch — possible CSRF'));
+          reject(new Error('Authorization state mismatch (CSRF guard tripped)'));
+          return;
+        }
+
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.end(SUCCESS_HTML);
+        resolve(gotCode);
+      });
+
+      server.on('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        const port = server.address().port;
+        timer = setTimeout(() => {
+          reject(new Error('Login timed out. Please run `megallm login` again.'));
+        }, timeoutMs);
+        if (signal) {
+          onAbort = () => reject(new Error('Login cancelled'));
+          if (signal.aborted) onAbort();
+          else signal.addEventListener('abort', onAbort, { once: true });
+        }
+        resolveOuter({ server, port, callback });
+      });
+    }).finally(() => {
+      if (timer) clearTimeout(timer);
+      if (onAbort && signal) signal.removeEventListener('abort', onAbort);
+    });
+
+    // If the server itself fails to listen, surface that on the outer promise
+    // so the caller doesn't hang forever.
+    callback.catch(rejectOuter);
+  });
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Heuristic: is this environment likely to have a working desktop browser?
+ * Used to decide between loopback (default) and device-code fallback.
+ */
+export function canUseLoopback() {
+  if (process.env.MEGALLM_FORCE_DEVICE_FLOW === '1') return false;
+  if (process.env.SSH_CONNECTION || process.env.SSH_TTY) return false;
+  if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+    return false;
+  }
+  return true;
 }

--- a/src/auth/oauth.js
+++ b/src/auth/oauth.js
@@ -1,0 +1,185 @@
+// OAuth 2.0 device authorization grant (RFC 8628) client for the MegaLLM web app.
+// Endpoints documented at <megallm.io>/dashboard/developers/docs.
+import { exec } from 'child_process';
+import {
+  MEGALLM_WEB_URL,
+  OAUTH_CLIENT_ID,
+  OAUTH_SCOPES,
+} from '../constants.js';
+
+const DEVICE_CODE_ENDPOINT = `${MEGALLM_WEB_URL}/api/oauth/device/code`;
+const TOKEN_ENDPOINT = `${MEGALLM_WEB_URL}/api/oauth/token`;
+const USERINFO_ENDPOINT = `${MEGALLM_WEB_URL}/api/oauth/userinfo`;
+const REVOKE_ENDPOINT = `${MEGALLM_WEB_URL}/api/oauth/revoke`;
+
+const USER_AGENT = `megallm-cli/${process.env.npm_package_version || '0.0.0'} (${process.platform})`;
+
+/** Open `url` in the user's default browser (best-effort, never throws). */
+export function openInBrowser(url) {
+  const cmd =
+    process.platform === 'darwin' ? 'open' :
+    process.platform === 'win32'  ? 'start ""' :
+                                    'xdg-open';
+  try {
+    exec(`${cmd} "${url}"`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Step 1 — request a device code + user code.
+ * Returns: { device_code, user_code, verification_uri, verification_uri_complete,
+ *            expires_in, interval }
+ */
+export async function startDeviceFlow({
+  clientId = OAUTH_CLIENT_ID,
+  scopes = OAUTH_SCOPES,
+} = {}) {
+  const body = new URLSearchParams({
+    client_id: clientId,
+    scope: scopes.join(' '),
+  });
+
+  const res = await fetch(DEVICE_CODE_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': USER_AGENT,
+    },
+    body: body.toString(),
+  });
+
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg = json.error_description || json.error || `HTTP ${res.status}`;
+    throw new Error(`Could not start login flow: ${msg}`);
+  }
+  return json;
+}
+
+/**
+ * Step 2 — poll the token endpoint until approved/denied/expired.
+ * Honors the server-supplied `interval` and RFC 8628 `slow_down`.
+ *
+ * @param {{ device_code: string, interval: number, expires_in: number, clientId?: string,
+ *           onTick?: (state: { secondsLeft: number }) => void,
+ *           signal?: AbortSignal }} opts
+ * Returns the token payload: { api_key, token_type, scopes, key_prefix }
+ */
+export async function pollForToken({
+  device_code,
+  interval,
+  expires_in,
+  clientId = OAUTH_CLIENT_ID,
+  onTick,
+  signal,
+}) {
+  const deadline = Date.now() + expires_in * 1000;
+  let waitMs = Math.max(1, interval) * 1000;
+
+  while (Date.now() < deadline) {
+    if (signal?.aborted) throw new Error('Login cancelled');
+
+    if (onTick) {
+      onTick({ secondsLeft: Math.max(0, Math.ceil((deadline - Date.now()) / 1000)) });
+    }
+
+    await sleep(waitMs, signal);
+
+    const body = new URLSearchParams({
+      grant_type: 'device_code',
+      device_code,
+      client_id: clientId,
+    });
+
+    let res;
+    try {
+      res = await fetch(TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'User-Agent': USER_AGENT,
+        },
+        body: body.toString(),
+        signal,
+      });
+    } catch (err) {
+      // Network blip — keep trying within deadline.
+      if (signal?.aborted) throw err;
+      continue;
+    }
+
+    const json = await res.json().catch(() => ({}));
+
+    if (res.ok) return json;
+
+    const code = json.error;
+    if (code === 'authorization_pending') {
+      // Keep waiting at the current interval.
+      continue;
+    }
+    if (code === 'slow_down') {
+      waitMs += 5000;
+      continue;
+    }
+    if (code === 'expired_token') {
+      throw new Error('Login code expired. Please run `megallm login` again.');
+    }
+    if (code === 'access_denied') {
+      throw new Error('Login was denied in the browser.');
+    }
+    // Anything else is a hard failure.
+    throw new Error(json.error_description || code || `HTTP ${res.status}`);
+  }
+  throw new Error('Login timed out. Please run `megallm login` again.');
+}
+
+/** GET /api/oauth/userinfo — confirms a stored key still works + returns identity. */
+export async function fetchUserInfo(apiKey) {
+  const res = await fetch(USERINFO_ENDPOINT, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'User-Agent': USER_AGENT,
+    },
+  });
+  if (!res.ok) {
+    if (res.status === 401) return null; // key invalid/revoked
+    const text = await res.text().catch(() => '');
+    throw new Error(`userinfo failed: HTTP ${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+/** App-initiated revoke — best-effort; we always wipe local state regardless. */
+export async function revokeApiKey(apiKey, clientId = OAUTH_CLIENT_ID) {
+  try {
+    await fetch(REVOKE_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': USER_AGENT,
+      },
+      body: new URLSearchParams({
+        client_id: clientId,
+        token: apiKey,
+      }).toString(),
+    });
+  } catch {
+    /* ignore */
+  }
+}
+
+function sleep(ms, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) return reject(new Error('Login cancelled'));
+    const t = setTimeout(resolve, ms);
+    if (signal) {
+      signal.addEventListener('abort', () => {
+        clearTimeout(t);
+        reject(new Error('Login cancelled'));
+      }, { once: true });
+    }
+  });
+}

--- a/src/auth/store.js
+++ b/src/auth/store.js
@@ -1,0 +1,130 @@
+// Persistent credential store at ~/.megallm/. Profile-aware (AWS CLI style).
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import {
+  MEGALLM_HOME,
+  MEGALLM_PROFILES_DIR,
+  MEGALLM_CONFIG_FILE,
+  DEFAULT_PROFILE,
+} from '../constants.js';
+
+/**
+ * Resolve the active profile name in this order:
+ *   1. explicit `--profile <name>` (caller passes it in)
+ *   2. $MEGALLM_PROFILE
+ *   3. config.json `current_profile`
+ *   4. "default"
+ */
+export function resolveProfileName(explicit) {
+  if (explicit && explicit.trim()) return explicit.trim();
+  if (process.env.MEGALLM_PROFILE) return process.env.MEGALLM_PROFILE.trim();
+  try {
+    const cfg = fs.readJsonSync(MEGALLM_CONFIG_FILE);
+    if (cfg?.current_profile) return cfg.current_profile;
+  } catch {
+    /* file missing — fall through */
+  }
+  return DEFAULT_PROFILE;
+}
+
+function profileDir(name) {
+  return path.join(MEGALLM_PROFILES_DIR, name);
+}
+
+function authPath(name) {
+  return path.join(profileDir(name), 'auth.json');
+}
+
+function statePath(name) {
+  return path.join(profileDir(name), 'state.json');
+}
+
+export async function ensureMegallmHome() {
+  await fs.ensureDir(MEGALLM_HOME);
+  // Best-effort tighten perms on Unix; ignore on Windows.
+  if (process.platform !== 'win32') {
+    try { await fs.chmod(MEGALLM_HOME, 0o700); } catch { /* ignore */ }
+  }
+  await fs.ensureDir(MEGALLM_PROFILES_DIR);
+}
+
+export async function listProfiles() {
+  try {
+    const entries = await fs.readdir(MEGALLM_PROFILES_DIR);
+    const out = [];
+    for (const e of entries) {
+      const ap = authPath(e);
+      if (await fs.pathExists(ap)) out.push(e);
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read the auth record for a profile. Returns null if missing or unreadable.
+ *
+ * Shape:
+ *   {
+ *     version: 1,
+ *     apiKey: "sk-mega-...",
+ *     keyPrefix: "sk-mega-abc...",
+ *     scopes: ["api:use", "profile:read", ...],
+ *     user: { sub, email, name, email_verified },
+ *     orgId: "org_abc",
+ *     orgName: "Acme",
+ *     savedAt: "2026-...",
+ *     clientId: "mega_pub_..."
+ *   }
+ */
+export async function readAuth(profile = DEFAULT_PROFILE) {
+  try {
+    return await fs.readJson(authPath(profile));
+  } catch {
+    return null;
+  }
+}
+
+export async function writeAuth(record, profile = DEFAULT_PROFILE) {
+  await ensureMegallmHome();
+  const dir = profileDir(profile);
+  await fs.ensureDir(dir);
+  const file = authPath(profile);
+  await fs.writeJson(file, { version: 1, savedAt: new Date().toISOString(), ...record }, { spaces: 2 });
+  if (process.platform !== 'win32') {
+    try { await fs.chmod(file, 0o600); } catch { /* ignore */ }
+    try { await fs.chmod(dir, 0o700); } catch { /* ignore */ }
+  }
+}
+
+export async function deleteAuth(profile = DEFAULT_PROFILE) {
+  try { await fs.remove(authPath(profile)); } catch { /* ignore */ }
+  try { await fs.remove(statePath(profile)); } catch { /* ignore */ }
+}
+
+export async function readState(profile = DEFAULT_PROFILE) {
+  try { return await fs.readJson(statePath(profile)); } catch { return {}; }
+}
+
+export async function writeState(state, profile = DEFAULT_PROFILE) {
+  await ensureMegallmHome();
+  await fs.ensureDir(profileDir(profile));
+  await fs.writeJson(statePath(profile), state, { spaces: 2 });
+}
+
+export async function setCurrentProfile(name) {
+  await ensureMegallmHome();
+  let cfg = {};
+  try { cfg = await fs.readJson(MEGALLM_CONFIG_FILE); } catch { /* new */ }
+  cfg.current_profile = name;
+  await fs.writeJson(MEGALLM_CONFIG_FILE, cfg, { spaces: 2 });
+}
+
+/** Mask all but the first 12 and last 4 chars for safe display. */
+export function maskApiKey(key) {
+  if (!key || typeof key !== 'string') return '';
+  if (key.length <= 20) return key.slice(0, 6) + '…';
+  return `${key.slice(0, 12)}…${key.slice(-4)}`;
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,13 +2,18 @@
 
 // Main CLI for MegaLLM Setup
 import chalk from 'chalk';
-import figlet from 'figlet';
+import gradient from 'gradient-string';
+import { buildWordmarkGrid, playShimmerOnce } from './tui/shimmer.js';
 import { detectOS } from './detectors/os.js';
 import { getInstalledTools, checkToolsStatus, isClaudeCodeInstalled, isCodexInstalled, isOpenCodeInstalled } from './detectors/tools.js';
 import {
   promptToolSelection,
   promptSetupLevel,
   promptApiKey,
+  promptApiKeyPaste,
+  promptAuthMethod,
+  promptOrgSelection,
+  printIdentityBanner,
   confirmConfiguration,
   promptRetry,
   promptExistingConfigAction,
@@ -24,20 +29,133 @@ import { configureStatusline, isStatuslineConfigured } from './configurators/sta
 import { reloadShell, setEnvironmentVariable } from './utils/shell.js';
 import { MEGALLM_BASE_URL, SETUP_LEVELS } from './constants.js';
 import { checkExistingConfiguration, removeEnvVars, detectExistingEnvVars, removeConfigurationFiles } from './utils/envDetector.js';
+import { loginWithBrowser } from './auth/login.js';
+import { readAuth, resolveProfileName, writeAuth, writeState } from './auth/store.js';
+import { fetchUserInfo } from './auth/oauth.js';
+import { listOrgs } from './auth/api.js';
+import { resolveKeyForOrg } from './auth/keys.js';
 
 /**
- * Display the MegaLLM branded ASCII banner and header for the setup tool.
+ * Resolve a usable MegaLLM API key for the wizard.
  *
- * Clears the terminal and prints a colored ASCII title, a subtitle listing supported tools,
- * a brief description, and a separator line.
+ * Order of preference:
+ *   1. If a saved CLI session exists and still works, offer to reuse it.
+ *   2. Otherwise let the user pick "login with browser" or "paste a key".
+ *
+ * The login path also runs the org picker if the account belongs to >1 org
+ * and mints a fresh per-org key so the key the wizard installs is scoped
+ * correctly out of the box.
+ *
+ * @returns {Promise<{ apiKey: string, source: 'login' | 'paste' | 'existing' }>}
+ */
+async function obtainApiKey() {
+  const profile = resolveProfileName();
+  const existing = await readAuth(profile);
+
+  let sessionLabel = '';
+  let sessionStillValid = false;
+  if (existing?.apiKey) {
+    // Quietly verify the saved key still works before offering it.
+    try {
+      const u = await fetchUserInfo(existing.apiKey);
+      if (u) {
+        sessionStillValid = true;
+        sessionLabel = u.email || u.name || existing.user?.email || 'saved session';
+      }
+    } catch { /* network blip — still offer it */ }
+  }
+
+  const method = await promptAuthMethod({
+    hasExistingSession: !!existing?.apiKey && sessionStillValid,
+    sessionLabel,
+  });
+
+  if (method === 'existing' && existing?.apiKey) {
+    printIdentityBanner({
+      user: existing.user,
+      orgName: existing.orgName,
+      apiKey: existing.apiKey,
+    });
+    return { apiKey: existing.apiKey, source: 'existing' };
+  }
+
+  if (method === 'paste') {
+    const k = await promptApiKeyPaste();
+    return { apiKey: k, source: 'paste' };
+  }
+
+  // method === 'login'
+  let record = await loginWithBrowser({ profile });
+
+  // If the account has multiple orgs, let the user pick one and mint a fresh
+  // per-org key. This mirrors AWS CLI's "default profile is your default org".
+  let orgs = [];
+  try { orgs = await listOrgs(record.apiKey); } catch { /* ignore */ }
+
+  if (orgs.length > 1) {
+    const chosenOrgId = await promptOrgSelection(orgs, { defaultOrgId: record.orgId });
+    if (chosenOrgId && chosenOrgId !== record.orgId) {
+      const chosenOrg = orgs.find(o => o.org_id === chosenOrgId);
+      try {
+        // Reuse a cached per-org key if it's still alive on the backend; only
+        // mint a fresh one when no live key exists for this org.
+        const resolved = await resolveKeyForOrg({
+          auth: record,
+          org: { org_id: chosenOrgId, org_name: chosenOrg?.org_name || null },
+          onProgress: (msg) => console.log(chalk.cyan(`\n🔑 ${msg}`)),
+        });
+        if (resolved.apiKey) {
+          if (resolved.reused) {
+            console.log(chalk.gray('  Reused saved key for this org.'));
+          } else {
+            console.log(chalk.green('  Minted a fresh key for this org.'));
+          }
+          record = {
+            ...record,
+            apiKey:    resolved.apiKey,
+            apiKeyId:  resolved.apiKeyId,
+            keyPrefix: resolved.keyPrefix,
+            orgId:     chosenOrgId,
+            orgName:   chosenOrg?.org_name || null,
+            keysByOrg: resolved.keysByOrg,
+          };
+          await writeAuth(record, profile);
+          await writeState({
+            current_org_id: record.orgId,
+            current_org_name: record.orgName,
+            orgs,
+          }, profile);
+        }
+      } catch (err) {
+        console.log(chalk.yellow(`⚠ Could not resolve a per-org key (${err.message}); using your default key.`));
+      }
+    }
+  }
+
+  printIdentityBanner({
+    user: record.user,
+    orgName: record.orgName,
+    apiKey: record.apiKey,
+  });
+  return { apiKey: record.apiKey, source: 'login' };
+}
+
+/**
+ * Render the wizard's branded welcome banner. Plays a one-shot diagonal
+ * shimmer over the cfonts "block" wordmark (top-left → bottom-right), then
+ * prints the gradient rule and tagline under it.
  */
 async function showBanner() {
   console.clear();
-  const banner = figlet.textSync('MegaLLM', { horizontalLayout: 'default' });
-  console.log(chalk.cyan(banner));
-  console.log(chalk.cyan('      Setup Tool for Claude Code, Codex & OpenCode'));
-  console.log(chalk.gray('      Configure your AI tools to use MegaLLM\n'));
-  console.log(chalk.gray('═'.repeat(50)));
+  const grid = buildWordmarkGrid('MegaLLM');
+  await playShimmerOnce(grid, { passes: 1 });
+  const brand = gradient(['#22d3ee', '#3b82f6']);
+  const rule = brand('━'.repeat(70));
+  console.log(rule);
+  console.log('');
+  console.log(' ' + chalk.cyan.bold('✻') + '  ' + chalk.bold('Configure Claude Code, Codex & OpenCode for MegaLLM'));
+  console.log('    ' + chalk.gray('Docs at megallm.io  ·  Run `megallm --help`'));
+  console.log('');
 }
 
 /**
@@ -372,8 +490,8 @@ async function main() {
     console.log(chalk.cyan('\n📋 Configuration Setup'));
     const selectedTool = await promptToolSelection(installedTools);
 
-    if (!selectedTool) {
-      console.log(chalk.yellow('\nSetup cancelled.'));
+    if (!selectedTool || selectedTool === 'skip') {
+      console.log(chalk.gray(`\nSkipped. Run ${chalk.bold('megallm setup')} or ${chalk.bold('megallm link <tool>')} any time.\n`));
       process.exit(0);
     }
 
@@ -388,8 +506,8 @@ async function main() {
       setupLevel = await promptSetupLevel();
     }
 
-    // Step 5: API Key input
-    const apiKey = await promptApiKey();
+    // Step 5: API Key — login with browser, paste, or reuse saved session.
+    const { apiKey } = await obtainApiKey();
 
     // Step 6: Confirm configuration
     const configSummary = {

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -7,10 +7,11 @@ import path from 'path';
 import { readAuth, resolveProfileName, maskApiKey } from '../auth/store.js';
 import { fetchUserInfo } from '../auth/oauth.js';
 import { checkToolsStatus } from '../detectors/tools.js';
-import { getEnvironmentVariable } from '../utils/shell.js';
+import { getEnvironmentVariable, setEnvironmentVariable, readPersistedEnvVar } from '../utils/shell.js';
 import { verifyClaudeConfig } from '../configurators/claude.js';
 import { verifyCodexConfig }  from '../configurators/codex.js';
 import { verifyOpenCodeConfig } from '../configurators/opencode.js';
+import { readJsonFile, readTomlFile } from '../utils/files.js';
 import { MEGALLM_HOME, MEGALLM_BASE_URL } from '../constants.js';
 
 const PASS = chalk.green('✓');
@@ -32,8 +33,63 @@ function compareSemver(a, b) {
   return 0;
 }
 
+// Pull the API key each tool would actually send to the backend at runtime.
+// Returns null when the tool has no resolvable key (config missing, env unset,
+// or the config doesn't reference a MegaLLM key).
+async function readToolApiKey(tool, configPath) {
+  try {
+    if (tool === 'claude') {
+      if (!configPath) return null;
+      const cfg = await readJsonFile(configPath);
+      const k = cfg?.env?.ANTHROPIC_API_KEY;
+      return k && typeof k === 'string' ? k : null;
+    }
+    if (tool === 'codex') {
+      if (!configPath) return null;
+      const cfg = await readTomlFile(configPath);
+      const envKey = cfg?.model_providers?.megallm?.env_key || 'MEGALLM_API_KEY';
+      // Prefer the live shell value; fall back to the rc file so a tool
+      // configured in a previous shell still gets validated.
+      return getEnvironmentVariable(envKey) || readPersistedEnvVar(envKey);
+    }
+    if (tool === 'opencode') {
+      if (!configPath) return null;
+      const cfg = await readJsonFile(configPath);
+      const ref = cfg?.provider?.anthropic?.options?.apiKey;
+      const m = typeof ref === 'string' ? ref.match(/^\{env:([A-Z0-9_]+)\}$/) : null;
+      const envName = m ? m[1] : 'MEGALLM_API_KEY';
+      return getEnvironmentVariable(envName) || readPersistedEnvVar(envName);
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+// Probe a key against /userinfo. Caches results so the same key is only hit once.
+//   active : key works, returns the identity payload
+//   revoked: backend returned 401 (key invalid / revoked / rotated)
+//   error  : transient / network / unexpected
+function makeKeyProber() {
+  const cache = new Map();
+  return async function probe(apiKey) {
+    if (!apiKey) return { status: 'missing' };
+    if (cache.has(apiKey)) return cache.get(apiKey);
+    let result;
+    try {
+      const info = await fetchUserInfo(apiKey);
+      result = info ? { status: 'active', info } : { status: 'revoked' };
+    } catch (err) {
+      result = { status: 'error', message: err.message };
+    }
+    cache.set(apiKey, result);
+    return result;
+  };
+}
+
 export async function runDoctor({ profile } = {}) {
   const r = new Report();
+  const probeKey = makeKeyProber();
   console.log(chalk.bold.cyan('MegaLLM doctor\n'));
 
   // 1. Runtime
@@ -76,8 +132,15 @@ export async function runDoctor({ profile } = {}) {
       } catch { /* ignore */ }
     }
     try {
-      const u = await fetchUserInfo(auth.apiKey);
-      r.ok(`Backend accepts the key`, `${u.email || u.name || 'identity confirmed'}`);
+      const probed = await probeKey(auth.apiKey);
+      if (probed.status === 'active') {
+        const u = probed.info;
+        r.ok(`Backend accepts the key`, `${u.email || u.name || 'identity confirmed'}`);
+      } else if (probed.status === 'revoked') {
+        r.fail(`Backend rejected the key`, 'key was revoked or rotated — run `megallm login`');
+      } else {
+        r.fail(`Backend rejected the key`, probed.message || 'unknown error');
+      }
     } catch (err) {
       r.fail(`Backend rejected the key`, err.message);
     }
@@ -127,7 +190,38 @@ export async function runDoctor({ profile } = {}) {
     }
   }
 
-  // 6. Environment variables
+  // 6. Tools — API key health (probe each tool's key against /userinfo)
+  r.section('Tools — API key health');
+  const toolKeyChecks = [
+    { key: 'claude',   label: 'Claude Code', info: t.claude,   keySource: 'config file',         hint: 'run `megallm doctor fix` to reconfigure ~/.claude/settings.json with the active key' },
+    { key: 'codex',    label: 'Codex',       info: t.codex,    keySource: 'MEGALLM_API_KEY env', hint: 'run `megallm doctor fix` to refresh MEGALLM_API_KEY in your shell rc' },
+    { key: 'opencode', label: 'OpenCode',    info: t.opencode, keySource: 'MEGALLM_API_KEY env', hint: 'run `megallm doctor fix` to refresh MEGALLM_API_KEY in your shell rc' },
+  ];
+  for (const c of toolKeyChecks) {
+    if (!c.info?.installed) { console.log(chalk.gray(`  · ${c.label}: skipped (not installed)`)); continue; }
+    const toolKey = await readToolApiKey(c.key, c.info.configPath);
+    if (!toolKey) {
+      console.log(chalk.gray(`  · ${c.label}: skipped (no key in ${c.keySource})`));
+      continue;
+    }
+    const probed = await probeKey(toolKey);
+    const masked = maskApiKey(toolKey);
+    if (probed.status === 'active') {
+      const ident = probed.info?.email || probed.info?.name || 'active';
+      if (auth?.apiKey && toolKey !== auth.apiKey) {
+        r.warn(`${c.label} key ${masked} is active but does not match profile key`,
+               'tool is on an older key — run `megallm doctor fix` to align them');
+      } else {
+        r.ok(`${c.label} key ${masked} is active`, ident);
+      }
+    } else if (probed.status === 'revoked') {
+      r.fail(`${c.label} key ${masked} is revoked`, c.hint);
+    } else {
+      r.warn(`${c.label} key ${masked}: could not verify`, probed.message || 'network error');
+    }
+  }
+
+  // 7. Environment variables
   r.section('Environment');
   const envChecks = [
     { name: 'ANTHROPIC_BASE_URL', expected: MEGALLM_BASE_URL,  required: true },
@@ -135,18 +229,28 @@ export async function runDoctor({ profile } = {}) {
     { name: 'MEGALLM_API_KEY',    startsWith: 'sk-mega-',       required: false },
   ];
   for (const e of envChecks) {
-    const v = getEnvironmentVariable(e.name);
+    const live = getEnvironmentVariable(e.name);
+    const persisted = readPersistedEnvVar(e.name);
+    const v = live || persisted;
+    const onlyPersisted = !live && !!persisted;
+
     if (!v) {
-      if (e.required) r.warn(`${e.name} not set`, 'open a new shell or run `source ~/.zshrc`');
+      if (e.required) r.warn(`${e.name} not set`, 'run `megallm doctor fix` to write it to your shell rc');
       else            console.log(chalk.gray(`  · ${e.name}: not set (optional)`));
       continue;
     }
-    if (e.expected && v !== e.expected)        r.warn(`${e.name}=${v}`, `expected ${e.expected}`);
-    else if (e.startsWith && !v.startsWith(e.startsWith)) r.warn(`${e.name}=${v.slice(0,12)}…`, `expected to start with ${e.startsWith}`);
-    else                                       r.ok(`${e.name} is set`);
+    if (e.expected && v !== e.expected) {
+      r.warn(`${e.name}=${v}`, `expected ${e.expected}`);
+    } else if (e.startsWith && !v.startsWith(e.startsWith)) {
+      r.warn(`${e.name}=${v.slice(0,12)}…`, `expected to start with ${e.startsWith}`);
+    } else if (onlyPersisted) {
+      r.ok(`${e.name} persisted in shell rc`, 'open a new shell or `source ~/.zshrc` to load it');
+    } else {
+      r.ok(`${e.name} is set`);
+    }
   }
 
-  // 7. Summary
+  // 8. Summary
   console.log('');
   if (r.fails === 0 && r.warns === 0) {
     console.log(chalk.green.bold('Everything looks good. ✨'));
@@ -154,6 +258,164 @@ export async function runDoctor({ profile } = {}) {
     console.log(`${r.fails ? chalk.red.bold(`${r.fails} failure(s)`) : ''}` +
                 `${r.fails && r.warns ? '  ' : ''}` +
                 `${r.warns ? chalk.yellow.bold(`${r.warns} warning(s)`) : ''}`);
-    if (r.fails > 0) process.exit(1);
+    if (r.fails > 0) {
+      console.log(chalk.gray('\nTip: many of these can be auto-repaired with `megallm doctor fix`.'));
+      process.exit(1);
+    }
   }
+}
+
+// ── doctor fix ─────────────────────────────────────────────────────────────
+//
+// Auto-remediates the most common breakages doctor reports:
+//   • Tool config holds a revoked / stale key  → re-run the tool's
+//     configurator with the active profile key.
+//   • MEGALLM_API_KEY / ANTHROPIC_API_KEY in the shell rc are missing or
+//     stale → rewrite them via setEnvironmentVariable so a fresh shell
+//     picks them up.
+//
+// Anything that needs human input (signing in, picking an org, installing a
+// missing tool) is intentionally *not* attempted here — `fix` only repairs
+// state derived from the saved profile.
+
+export async function runDoctorFix({ profile } = {}) {
+  console.log(chalk.bold.cyan('MegaLLM doctor — fix\n'));
+
+  const probeKey = makeKeyProber();
+  const profileName = resolveProfileName(profile);
+  const auth = await readAuth(profileName);
+
+  if (!auth?.apiKey) {
+    console.log(`  ${FAIL} No saved credentials for profile ${chalk.white(profileName)}`);
+    console.log(chalk.gray('    Run `megallm login` first, then re-run `megallm doctor fix`.'));
+    process.exit(1);
+  }
+
+  // The profile key itself must be alive — we can't push a dead key into the
+  // tools and call that "fixed".
+  const probed = await probeKey(auth.apiKey);
+  if (probed.status === 'revoked') {
+    console.log(`  ${FAIL} Saved profile key ${maskApiKey(auth.apiKey)} is revoked`);
+    console.log(chalk.gray('    Run `megallm login` to mint a new key, then re-run `megallm doctor fix`.'));
+    process.exit(1);
+  }
+  if (probed.status === 'error') {
+    console.log(`  ${FAIL} Could not reach the backend to verify the saved key`);
+    console.log(chalk.gray(`    ${probed.message}`));
+    process.exit(1);
+  }
+  console.log(`  ${PASS} Profile ${chalk.white(profileName)} → ${probed.info?.email || 'identity confirmed'} (${maskApiKey(auth.apiKey)})\n`);
+
+  const t = checkToolsStatus();
+  const tasks = [
+    { key: 'claude',   label: 'Claude Code', info: t.claude,
+      configure: async (k) => {
+        const { configureClaude } = await import('../configurators/claude.js');
+        return configureClaude(k, 'system');
+      },
+      // Claude embeds the key inline in settings.json *and* honors
+      // ANTHROPIC_API_KEY in the shell — keep them aligned.
+      envVars: [
+        { name: 'ANTHROPIC_BASE_URL', value: MEGALLM_BASE_URL },
+        { name: 'ANTHROPIC_API_KEY',  value: auth.apiKey },
+      ],
+    },
+    { key: 'codex',    label: 'Codex',       info: t.codex,
+      configure: async (k) => {
+        const { configureCodex } = await import('../configurators/codex.js');
+        return configureCodex(k, 'system');
+      },
+      envVars: [{ name: 'MEGALLM_API_KEY', value: auth.apiKey }],
+    },
+    { key: 'opencode', label: 'OpenCode',    info: t.opencode,
+      configure: async (k) => {
+        const { configureOpenCode } = await import('../configurators/opencode.js');
+        return configureOpenCode(k, 'system');
+      },
+      envVars: [{ name: 'MEGALLM_API_KEY', value: auth.apiKey }],
+    },
+  ];
+
+  let repaired = 0;
+  let alreadyOk = 0;
+  let failed = 0;
+  let envWritten = 0;
+  const touchedEnv = new Set();
+
+  for (const task of tasks) {
+    if (!task.info?.installed) {
+      console.log(chalk.gray(`  · ${task.label}: skipped (not installed)`));
+      continue;
+    }
+
+    const currentKey = await readToolApiKey(task.key, task.info.configPath);
+    let needsConfigure = false;
+    let reason = '';
+
+    if (!currentKey) {
+      needsConfigure = true;
+      reason = 'no key resolved';
+    } else if (currentKey !== auth.apiKey) {
+      const cur = await probeKey(currentKey);
+      if (cur.status === 'revoked')      { needsConfigure = true; reason = 'current key is revoked'; }
+      else if (cur.status === 'active')  { needsConfigure = true; reason = 'current key does not match profile'; }
+      else                               { needsConfigure = true; reason = `could not verify current key (${cur.message || 'unknown'})`; }
+    }
+
+    if (!needsConfigure) {
+      console.log(`  ${PASS} ${task.label} already on the active profile key`);
+      alreadyOk++;
+    } else {
+      console.log(chalk.cyan(`  → ${task.label}: ${reason} — reconfiguring...`));
+      try {
+        const ok = await task.configure(auth.apiKey);
+        if (ok) {
+          console.log(`  ${PASS} ${task.label} reconfigured`);
+          repaired++;
+        } else {
+          console.log(`  ${FAIL} ${task.label} configurator returned a failure`);
+          failed++;
+        }
+      } catch (err) {
+        console.log(`  ${FAIL} ${task.label} reconfiguration threw: ${err.message}`);
+        failed++;
+      }
+    }
+
+    // Always make sure the env vars this tool relies on are in place — even
+    // when the tool's config file already had the right key, the shell rc
+    // can still be missing the export. Compare against the persisted rc
+    // value so a re-run doesn't keep rewriting the same line.
+    for (const ev of task.envVars) {
+      if (touchedEnv.has(ev.name)) continue;
+      const persisted = readPersistedEnvVar(ev.name);
+      if (persisted === ev.value) {
+        touchedEnv.add(ev.name);
+        continue;
+      }
+      const wrote = setEnvironmentVariable(ev.name, ev.value, true);
+      if (wrote) {
+        console.log(`  ${PASS} ${ev.name} written to shell rc`);
+        envWritten++;
+        touchedEnv.add(ev.name);
+      } else {
+        console.log(`  ${FAIL} could not write ${ev.name} to shell rc`);
+        failed++;
+      }
+    }
+  }
+
+  // Summary
+  console.log('');
+  const parts = [];
+  if (repaired)   parts.push(chalk.green.bold(`${repaired} repaired`));
+  if (envWritten) parts.push(chalk.green(`${envWritten} env var(s) written`));
+  if (alreadyOk)  parts.push(chalk.gray(`${alreadyOk} already healthy`));
+  if (failed)     parts.push(chalk.red.bold(`${failed} failed`));
+  console.log(parts.length ? parts.join('  ·  ') : chalk.gray('Nothing to do.'));
+
+  if (envWritten > 0) {
+    console.log(chalk.yellow('\n⚠ Open a new shell (or `source ~/.zshrc`) so the env vars take effect for tools that read them at startup.'));
+  }
+  if (failed > 0) process.exit(1);
 }

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,0 +1,159 @@
+// `megallm doctor` — runs every health check we know about and prints a
+// digestible report.  Returns a non-zero exit code when any *critical* check
+// fails, so it can plug into CI / shell scripts.
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+import { readAuth, resolveProfileName, maskApiKey } from '../auth/store.js';
+import { fetchUserInfo } from '../auth/oauth.js';
+import { checkToolsStatus } from '../detectors/tools.js';
+import { getEnvironmentVariable } from '../utils/shell.js';
+import { verifyClaudeConfig } from '../configurators/claude.js';
+import { verifyCodexConfig }  from '../configurators/codex.js';
+import { verifyOpenCodeConfig } from '../configurators/opencode.js';
+import { MEGALLM_HOME, MEGALLM_BASE_URL } from '../constants.js';
+
+const PASS = chalk.green('✓');
+const WARN = chalk.yellow('!');
+const FAIL = chalk.red('✗');
+
+class Report {
+  constructor() { this.fails = 0; this.warns = 0; }
+  ok(msg, hint)   { console.log(`  ${PASS} ${msg}${hint ? chalk.gray('  — ' + hint) : ''}`); }
+  warn(msg, hint) { this.warns++; console.log(`  ${WARN} ${msg}${hint ? chalk.gray('  — ' + hint) : ''}`); }
+  fail(msg, hint) { this.fails++; console.log(`  ${FAIL} ${msg}${hint ? chalk.gray('  — ' + hint) : ''}`); }
+  section(title)  { console.log(''); console.log(chalk.bold(title)); console.log(chalk.gray('─'.repeat(title.length))); }
+}
+
+function compareSemver(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) if ((pa[i] || 0) !== (pb[i] || 0)) return (pa[i] || 0) - (pb[i] || 0);
+  return 0;
+}
+
+export async function runDoctor({ profile } = {}) {
+  const r = new Report();
+  console.log(chalk.bold.cyan('MegaLLM doctor\n'));
+
+  // 1. Runtime
+  r.section('Runtime');
+  const nodeVer = process.versions.node;
+  if (compareSemver(nodeVer, '18.0.0') >= 0) r.ok(`Node.js ${nodeVer}`);
+  else r.fail(`Node.js ${nodeVer}`, 'Ink requires Node 18+');
+
+  // 2. ~/.megallm directory + perms
+  r.section('Local store');
+  if (await fs.pathExists(MEGALLM_HOME)) {
+    r.ok(`${MEGALLM_HOME} exists`);
+    if (process.platform !== 'win32') {
+      try {
+        const st = await fs.stat(MEGALLM_HOME);
+        const mode = (st.mode & 0o777).toString(8);
+        if (mode === '700') r.ok(`Permissions are 0700`);
+        else r.warn(`Permissions are 0${mode}`, 'expected 0700');
+      } catch { /* ignore */ }
+    }
+  } else {
+    r.warn(`${MEGALLM_HOME} missing`, 'created automatically on first login');
+  }
+
+  // 3. Profile + identity
+  r.section('Identity');
+  const name = resolveProfileName(profile);
+  console.log(`  Profile: ${chalk.white(name)}`);
+  const auth = await readAuth(name);
+  if (!auth?.apiKey) {
+    r.fail('Not signed in', 'run `megallm login`');
+  } else {
+    r.ok(`Saved key ${maskApiKey(auth.apiKey)}`);
+    if (process.platform !== 'win32') {
+      try {
+        const st = await fs.stat(path.join(MEGALLM_HOME, 'profiles', name, 'auth.json'));
+        const mode = (st.mode & 0o777).toString(8);
+        if (mode === '600') r.ok('auth.json permissions are 0600');
+        else r.warn(`auth.json permissions are 0${mode}`, 'expected 0600');
+      } catch { /* ignore */ }
+    }
+    try {
+      const u = await fetchUserInfo(auth.apiKey);
+      r.ok(`Backend accepts the key`, `${u.email || u.name || 'identity confirmed'}`);
+    } catch (err) {
+      r.fail(`Backend rejected the key`, err.message);
+    }
+    const requiredScopes = ['api:use', 'profile:read', 'keys:read', 'keys:manage'];
+    const have = new Set(auth.scopes || []);
+    const missing = requiredScopes.filter(s => !have.has(s));
+    if (missing.length === 0) r.ok(`Scopes: ${requiredScopes.join(', ')}`);
+    else r.warn(`Missing scopes: ${missing.join(', ')}`, 're-run `megallm login` after enabling them in the OAuth app');
+  }
+
+  // 4. Tools — installed?
+  r.section('Tools — installation');
+  const t = checkToolsStatus();
+  for (const [key, label] of [['claude','Claude Code'],['codex','Codex'],['opencode','OpenCode']]) {
+    const i = t[key];
+    if (i?.installed) r.ok(`${label}`, i.configPath || i.path || 'detected');
+    else              r.warn(`${label} not installed`, 'install it then run `megallm setup`');
+  }
+
+  // 5. Tools — config validity
+  r.section('Tools — MegaLLM wiring');
+  const verifiers = [
+    { key: 'claude',   label: 'Claude Code', verify: verifyClaudeConfig,   info: t.claude   },
+    { key: 'codex',    label: 'Codex',       verify: verifyCodexConfig,    info: t.codex    },
+    { key: 'opencode', label: 'OpenCode',    verify: verifyOpenCodeConfig, info: t.opencode },
+  ];
+  for (const v of verifiers) {
+    if (!v.info?.installed) { console.log(chalk.gray(`  · ${v.label}: skipped (not installed)`)); continue; }
+    if (!v.info.configPath) { r.warn(`${v.label}: no config file`); continue; }
+    try {
+      const result = await v.verify(v.info.configPath);
+      if (result.valid) {
+        r.ok(`${v.label} configured for MegaLLM`);
+      } else if (result.details && result.details.apiKeySet === false
+                 && result.details.baseUrl !== false
+                 && result.details.megallmConfig !== false
+                 && result.details.envKey !== false
+                 && result.details.apiKeyRef !== false) {
+        // Config file is correct; only the runtime env var is unset, which
+        // the Environment section reports separately.
+        r.ok(`${v.label} configured for MegaLLM`);
+      } else {
+        r.fail(`${v.label} not configured for MegaLLM`, result.error || 'config check failed');
+      }
+    } catch (err) {
+      r.fail(`${v.label}: ${err.message}`);
+    }
+  }
+
+  // 6. Environment variables
+  r.section('Environment');
+  const envChecks = [
+    { name: 'ANTHROPIC_BASE_URL', expected: MEGALLM_BASE_URL,  required: true },
+    { name: 'ANTHROPIC_API_KEY',  startsWith: 'sk-mega-',       required: true },
+    { name: 'MEGALLM_API_KEY',    startsWith: 'sk-mega-',       required: false },
+  ];
+  for (const e of envChecks) {
+    const v = getEnvironmentVariable(e.name);
+    if (!v) {
+      if (e.required) r.warn(`${e.name} not set`, 'open a new shell or run `source ~/.zshrc`');
+      else            console.log(chalk.gray(`  · ${e.name}: not set (optional)`));
+      continue;
+    }
+    if (e.expected && v !== e.expected)        r.warn(`${e.name}=${v}`, `expected ${e.expected}`);
+    else if (e.startsWith && !v.startsWith(e.startsWith)) r.warn(`${e.name}=${v.slice(0,12)}…`, `expected to start with ${e.startsWith}`);
+    else                                       r.ok(`${e.name} is set`);
+  }
+
+  // 7. Summary
+  console.log('');
+  if (r.fails === 0 && r.warns === 0) {
+    console.log(chalk.green.bold('Everything looks good. ✨'));
+  } else {
+    console.log(`${r.fails ? chalk.red.bold(`${r.fails} failure(s)`) : ''}` +
+                `${r.fails && r.warns ? '  ' : ''}` +
+                `${r.warns ? chalk.yellow.bold(`${r.warns} warning(s)`) : ''}`);
+    if (r.fails > 0) process.exit(1);
+  }
+}

--- a/src/commands/hub.js
+++ b/src/commands/hub.js
@@ -42,6 +42,11 @@ export async function runHub({ profile } = {}) {
         await runDoctor({ profile });
         break;
       }
+      case 'doctor-fix': {
+        const { runDoctorFix } = await import('./doctor.js');
+        await runDoctorFix({ profile });
+        break;
+      }
       case 'logout': {
         const { runLogout } = await import('./logout.js');
         await runLogout({ profile });

--- a/src/commands/hub.js
+++ b/src/commands/hub.js
@@ -1,0 +1,63 @@
+// `megallm` (no args, TTY) — Ink hub.
+// Renders the hub, captures the user's menu pick, and dispatches to the
+// matching subcommand handler.  Subcommands run *after* Ink has unmounted, so
+// they get a clean stdout for inquirer / chalk output.
+import chalk from 'chalk';
+import { runInkHub } from '../tui/Hub.js';
+import { releaseStdinHandoff } from '../tui/stdin.js';
+
+export async function runHub({ profile } = {}) {
+  while (true) {
+    const pick = await runInkHub({ profile });
+
+    switch (pick) {
+      case 'login': {
+        const { runLogin } = await import('./login.js');
+        await runLogin({ profile, setCurrent: !!profile, autoConfigure: true });
+        break;
+      }
+      case 'setup': {
+        const { default: main } = await import('../cli.js');
+        await main();
+        releaseStdinHandoff();
+        return; // wizard already prints its own farewell
+      }
+      case 'switch-org': {
+        const { runSwitchOrg } = await import('./switch-org.js');
+        await runSwitchOrg({ profile });
+        break;
+      }
+      case 'keys': {
+        const { runKeysList } = await import('./keys.js');
+        await runKeysList({ profile });
+        break;
+      }
+      case 'status': {
+        const { runStatus } = await import('./status.js');
+        await runStatus({ profile });
+        break;
+      }
+      case 'doctor': {
+        const { runDoctor } = await import('./doctor.js');
+        await runDoctor({ profile });
+        break;
+      }
+      case 'logout': {
+        const { runLogout } = await import('./logout.js');
+        await runLogout({ profile });
+        break;
+      }
+      case 'exit':
+      default:
+        console.log(chalk.gray('\nBye 👋\n'));
+        releaseStdinHandoff();
+        return;
+    }
+
+    console.log('');
+    console.log(chalk.gray('Press Ctrl+C to quit, or wait — opening hub again…\n'));
+    // Brief pause so the user can read the previous output before the hub
+    // re-renders and clears the screen-region above.
+    await new Promise(r => setTimeout(r, 700));
+  }
+}

--- a/src/commands/keys.js
+++ b/src/commands/keys.js
@@ -1,0 +1,64 @@
+// `megallm keys list|revoke` — manage API keys for the active org.
+import chalk from 'chalk';
+import { readAuth, resolveProfileName, maskApiKey } from '../auth/store.js';
+import { listKeys, revokeKey } from '../auth/api.js';
+
+export async function runKeysList({ profile, orgId } = {}) {
+  const name = resolveProfileName(profile);
+  const auth = await readAuth(name);
+  if (!auth?.apiKey) {
+    console.log(chalk.yellow(`Not logged in (profile "${name}"). Run \`megallm login\`.`));
+    process.exit(1);
+  }
+  const target = orgId || auth.orgId;
+  if (!target) {
+    console.log(chalk.yellow('No org_id given and no active org saved. Run `megallm orgs` to find one.'));
+    process.exit(1);
+  }
+
+  let payload;
+  try { payload = await listKeys(auth.apiKey, target); }
+  catch (err) {
+    console.log(chalk.red(`✗ ${err.message}`));
+    process.exit(1);
+  }
+
+  const keys = payload?.keys || payload?.data || payload || [];
+  if (!keys.length) {
+    console.log(chalk.yellow(`No API keys in org ${target}.`));
+    return;
+  }
+
+  console.log(chalk.cyan(`\nKeys for org ${target}`));
+  console.log(chalk.gray('─'.repeat(60)));
+  for (const k of keys) {
+    const id = k.api_key_id || k.id || '';
+    const label = k.api_key_name || k.name || '(unnamed)';
+    const prefix = k.key_prefix || k.prefix || '';
+    const created = k.created_at || k.createdAt || '';
+    console.log(`  ${chalk.white(label)}  ${chalk.gray(prefix)}`);
+    console.log(chalk.gray(`    id: ${id}${created ? '  ·  created: ' + new Date(created).toLocaleDateString() : ''}`));
+  }
+  console.log('');
+  console.log(chalk.gray(`Revoke with: ${chalk.bold('megallm keys revoke <key_id>')}`));
+}
+
+export async function runKeysRevoke({ profile, keyId } = {}) {
+  if (!keyId) {
+    console.log(chalk.red('✗ Missing key_id. Usage: megallm keys revoke <key_id>'));
+    process.exit(1);
+  }
+  const name = resolveProfileName(profile);
+  const auth = await readAuth(name);
+  if (!auth?.apiKey) {
+    console.log(chalk.yellow(`Not logged in (profile "${name}"). Run \`megallm login\`.`));
+    process.exit(1);
+  }
+  try {
+    await revokeKey(auth.apiKey, keyId);
+    console.log(chalk.green(`✓ Revoked ${keyId}`));
+  } catch (err) {
+    console.log(chalk.red(`✗ ${err.message}`));
+    process.exit(1);
+  }
+}

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -1,0 +1,56 @@
+// `megallm link <tool>` and `megallm unlink <tool>` — wire or unwire a single
+// tool's config without running the full setup wizard.
+import chalk from 'chalk';
+import { readAuth, resolveProfileName } from '../auth/store.js';
+import { configureClaude, unconfigureClaude } from '../configurators/claude.js';
+import { configureCodex, unconfigureCodex }     from '../configurators/codex.js';
+import { configureOpenCode, unconfigureOpenCode } from '../configurators/opencode.js';
+import { setEnvironmentVariable } from '../utils/shell.js';
+import { MEGALLM_BASE_URL } from '../constants.js';
+
+const TOOLS = {
+  claude:   { label: 'Claude Code', wire: configureClaude,   unwire: unconfigureClaude   },
+  codex:    { label: 'Codex',       wire: configureCodex,    unwire: unconfigureCodex    },
+  opencode: { label: 'OpenCode',    wire: configureOpenCode, unwire: unconfigureOpenCode },
+};
+
+function bail(msg, code = 1) {
+  console.error(chalk.red(msg));
+  process.exit(code);
+}
+
+export async function runLink({ profile, tool } = {}) {
+  if (!tool) bail('Usage: megallm link <claude|codex|opencode>');
+  const def = TOOLS[tool.toLowerCase()];
+  if (!def) bail(`Unknown tool "${tool}". Pick one of: ${Object.keys(TOOLS).join(', ')}`);
+
+  const name = resolveProfileName(profile);
+  const auth = await readAuth(name);
+  if (!auth?.apiKey) {
+    console.log(chalk.yellow(`Not signed in (profile "${name}"). Run \`megallm login\` first.`));
+    process.exit(1);
+  }
+
+  const ok = await def.wire(auth.apiKey, 'system');
+  if (!ok) process.exit(1);
+
+  // Always set the env vars too so the tool actually picks the key up.
+  setEnvironmentVariable('ANTHROPIC_BASE_URL', MEGALLM_BASE_URL, true);
+  setEnvironmentVariable('ANTHROPIC_API_KEY', auth.apiKey, true);
+  setEnvironmentVariable('MEGALLM_API_KEY',   auth.apiKey, true);
+  console.log(chalk.green(`\n✓ Linked ${def.label} to MegaLLM.`));
+}
+
+export async function runUnlink({ tool } = {}) {
+  if (!tool) bail('Usage: megallm unlink <claude|codex|opencode>');
+  const def = TOOLS[tool.toLowerCase()];
+  if (!def) bail(`Unknown tool "${tool}". Pick one of: ${Object.keys(TOOLS).join(', ')}`);
+
+  const result = await def.unwire('system');
+  if (result.removed) {
+    console.log(chalk.green(`✓ Removed MegaLLM keys from ${def.label} (${result.configPath}).`));
+  } else {
+    console.log(chalk.gray(`• ${def.label}: ${result.reason || 'nothing to unlink'}.`));
+  }
+  console.log(chalk.gray('Tip: open a new shell so any old env vars stop applying.'));
+}

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -6,9 +6,9 @@ import { releaseStdinHandoff } from '../tui/stdin.js';
 import { resolveProfileName, setCurrentProfile } from '../auth/store.js';
 import { promptAndConfigureTools } from '../utils/configure-tools.js';
 
-export async function runLogin({ profile, setCurrent, autoConfigure = true } = {}) {
+export async function runLogin({ profile, setCurrent, autoConfigure = true, noBrowser = false } = {}) {
   const name = resolveProfileName(profile);
-  const record = await runInkLogin({ profile: name });
+  const record = await runInkLogin({ profile: name, forceDeviceFlow: noBrowser });
   if (setCurrent) await setCurrentProfile(name);
 
   console.log(chalk.gray(`Credentials saved to ~/.megallm/profiles/${name}/auth.json`));

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -1,0 +1,31 @@
+// `megallm login` — runs the Ink-rendered OAuth device flow.
+// On success, asks if the user wants to configure their tools right now.
+import chalk from 'chalk';
+import { runInkLogin } from '../tui/Login.js';
+import { releaseStdinHandoff } from '../tui/stdin.js';
+import { resolveProfileName, setCurrentProfile } from '../auth/store.js';
+import { promptAndConfigureTools } from '../utils/configure-tools.js';
+
+export async function runLogin({ profile, setCurrent, autoConfigure = true } = {}) {
+  const name = resolveProfileName(profile);
+  const record = await runInkLogin({ profile: name });
+  if (setCurrent) await setCurrentProfile(name);
+
+  console.log(chalk.gray(`Credentials saved to ~/.megallm/profiles/${name}/auth.json`));
+
+  if (!autoConfigure) {
+    releaseStdinHandoff();
+    return;
+  }
+
+  console.log('');
+  const { picked } = await promptAndConfigureTools(record.apiKey, {
+    message: 'Which tool would you like to configure with this key?',
+    skipHint: `Skipped. You can run ${chalk.bold('megallm setup')} or ${chalk.bold('megallm link <tool>')} any time.`,
+  });
+
+  if (picked !== 'skip') {
+    console.log(chalk.green('\n🎉  All set. Open a new shell or run `source ~/.zshrc` to pick up the env vars.\n'));
+  }
+  releaseStdinHandoff();
+}

--- a/src/commands/logout.js
+++ b/src/commands/logout.js
@@ -1,0 +1,17 @@
+// `megallm logout` — revokes the saved key (best-effort) and removes local creds.
+import chalk from 'chalk';
+import { readAuth, deleteAuth, resolveProfileName } from '../auth/store.js';
+import { revokeApiKey } from '../auth/oauth.js';
+
+export async function runLogout({ profile } = {}) {
+  const name = resolveProfileName(profile);
+  const auth = await readAuth(name);
+  if (!auth?.apiKey) {
+    console.log(chalk.yellow(`No saved credentials for profile "${name}".`));
+    return;
+  }
+  console.log(chalk.cyan(`Revoking key and clearing profile "${name}"…`));
+  await revokeApiKey(auth.apiKey, auth.clientId);
+  await deleteAuth(name);
+  console.log(chalk.green('✓ Logged out.'));
+}

--- a/src/commands/orgs.js
+++ b/src/commands/orgs.js
@@ -1,0 +1,33 @@
+// `megallm orgs` — list the orgs the current session can switch into.
+import chalk from 'chalk';
+import { readAuth, resolveProfileName } from '../auth/store.js';
+import { listOrgs } from '../auth/api.js';
+
+export async function runOrgs({ profile } = {}) {
+  const name = resolveProfileName(profile);
+  const auth = await readAuth(name);
+  if (!auth?.apiKey) {
+    console.log(chalk.yellow(`Not logged in (profile "${name}"). Run \`megallm login\`.`));
+    process.exit(1);
+  }
+  let orgs;
+  try { orgs = await listOrgs(auth.apiKey); }
+  catch (err) {
+    console.log(chalk.red(`✗ ${err.message}`));
+    process.exit(1);
+  }
+  if (!orgs.length) {
+    console.log(chalk.yellow('No organizations found for this account.'));
+    return;
+  }
+  console.log(chalk.cyan('\nOrganizations'));
+  console.log(chalk.gray('─'.repeat(48)));
+  for (const o of orgs) {
+    const active = auth.orgId === o.org_id ? chalk.green(' ★') : '  ';
+    const role = o.role ? chalk.gray(` (${o.role})`) : '';
+    console.log(`${active} ${chalk.white(o.org_name)}${role}`);
+    console.log(chalk.gray(`     ${o.org_id}`));
+  }
+  console.log('');
+  console.log(chalk.gray(`Switch with: ${chalk.bold('megallm switch-org <org_id>')}`));
+}

--- a/src/commands/profile.js
+++ b/src/commands/profile.js
@@ -1,0 +1,75 @@
+// `megallm profile list | use <name> | rm <name>` — manage named credential
+// profiles stored under ~/.megallm/profiles/.
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+import {
+  listProfiles,
+  setCurrentProfile,
+  resolveProfileName,
+  readAuth,
+  maskApiKey,
+} from '../auth/store.js';
+import { MEGALLM_PROFILES_DIR } from '../constants.js';
+
+function profileDir(name) {
+  return path.join(MEGALLM_PROFILES_DIR, name);
+}
+
+export async function runProfileList() {
+  const names = await listProfiles();
+  const current = resolveProfileName(); // honours config.json + env
+  if (names.length === 0) {
+    console.log(chalk.yellow('No profiles yet. Run `megallm login` to create one.'));
+    return;
+  }
+  console.log(chalk.bold('Profiles'));
+  console.log(chalk.gray('────────'));
+  for (const n of names) {
+    const auth = await readAuth(n);
+    const marker = n === current ? chalk.green('★') : ' ';
+    const who = auth?.user?.email || auth?.user?.name || chalk.gray('(no identity)');
+    const org = auth?.orgName ? chalk.gray(` · ${auth.orgName}`) : '';
+    const key = auth?.apiKey ? chalk.gray(` · ${maskApiKey(auth.apiKey)}`) : '';
+    console.log(`${marker} ${chalk.white(n.padEnd(16))} ${who}${org}${key}`);
+  }
+  console.log('');
+  console.log(chalk.gray('★ = current profile.  Switch with `megallm profile use <name>`.'));
+}
+
+export async function runProfileUse({ name } = {}) {
+  if (!name) {
+    console.error(chalk.red('Usage: megallm profile use <name>'));
+    process.exit(1);
+  }
+  const names = await listProfiles();
+  if (!names.includes(name)) {
+    console.error(chalk.red(`No profile "${name}". Existing: ${names.join(', ') || '(none)'}.`));
+    process.exit(1);
+  }
+  await setCurrentProfile(name);
+  console.log(chalk.green(`✓ Active profile is now "${name}".`));
+  console.log(chalk.gray('  (Other shells inherit via ~/.megallm/config.json.)'));
+}
+
+export async function runProfileRm({ name } = {}) {
+  if (!name) {
+    console.error(chalk.red('Usage: megallm profile rm <name>'));
+    process.exit(1);
+  }
+  const current = resolveProfileName();
+  if (name === current) {
+    console.error(chalk.red(
+      `Refusing to delete the active profile "${name}". ` +
+      `Switch with \`megallm profile use <other>\` first.`,
+    ));
+    process.exit(1);
+  }
+  const dir = profileDir(name);
+  if (!await fs.pathExists(dir)) {
+    console.error(chalk.red(`No profile "${name}".`));
+    process.exit(1);
+  }
+  await fs.remove(dir);
+  console.log(chalk.green(`✓ Removed profile "${name}".`));
+}

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -1,0 +1,47 @@
+// `megallm status` — plain-text snapshot of the current environment.
+// Designed to be scriptable: every field is printed even when empty so that
+// shell consumers can `grep` deterministically.
+import chalk from 'chalk';
+import { readAuth, resolveProfileName, maskApiKey } from '../auth/store.js';
+import { fetchUserInfo } from '../auth/oauth.js';
+import { checkToolsStatus } from '../detectors/tools.js';
+import { MEGALLM_BASE_URL, MEGALLM_WEB_URL } from '../constants.js';
+
+export async function runStatus({ profile } = {}) {
+  const name = resolveProfileName(profile);
+  const auth = await readAuth(name);
+
+  console.log(chalk.bold('MegaLLM CLI status'));
+  console.log(chalk.gray('──────────────────'));
+  console.log(`Profile           : ${chalk.white(name)}`);
+  console.log(`Backend (API)     : ${chalk.gray(MEGALLM_BASE_URL)}`);
+  console.log(`Backend (Web)     : ${chalk.gray(MEGALLM_WEB_URL)}`);
+
+  if (!auth?.apiKey) {
+    console.log(`Signed in         : ${chalk.yellow('no')}`);
+    console.log(chalk.gray(`\nRun ${chalk.bold('megallm login')} to sign in.`));
+  } else {
+    let identity = null;
+    try { identity = await fetchUserInfo(auth.apiKey); } catch { /* keep saved */ }
+    const user = identity || auth.user || {};
+    console.log(`Signed in         : ${chalk.green('yes')}`);
+    console.log(`User              : ${chalk.white(user.name || user.email || '(unknown)')}`);
+    console.log(`Email             : ${chalk.white(user.email || '—')}`);
+    console.log(`Active org        : ${chalk.white(auth.orgName || auth.orgId || '(default)')}`);
+    console.log(`API key           : ${chalk.white(maskApiKey(auth.apiKey))}`);
+    console.log(`Scopes            : ${chalk.white((auth.scopes || []).join(', ') || '—')}`);
+  }
+
+  console.log('');
+  console.log(chalk.bold('Detected tools'));
+  console.log(chalk.gray('──────────────'));
+  const t = checkToolsStatus();
+  for (const [key, label] of [['claude', 'Claude Code'], ['codex', 'Codex'], ['opencode', 'OpenCode']]) {
+    const info = t[key];
+    const ok = !!info?.installed;
+    const mark = ok ? chalk.green('✓') : chalk.gray('✗');
+    const detail = ok ? (info.configPath || 'detected') : 'not installed';
+    console.log(`${mark} ${label.padEnd(14)} ${chalk.gray(detail)}`);
+  }
+  console.log('');
+}

--- a/src/commands/switch-org.js
+++ b/src/commands/switch-org.js
@@ -1,0 +1,107 @@
+// `megallm switch-org <org_id>` — mint or reuse a per-org key and rewrite tool configs.
+import chalk from 'chalk';
+import { brailleOra as ora } from '../utils/spinner.js';
+import {
+  readAuth,
+  writeAuth,
+  writeState,
+  resolveProfileName,
+  maskApiKey,
+} from '../auth/store.js';
+import { listOrgs } from '../auth/api.js';
+import { resolveKeyForOrg } from '../auth/keys.js';
+import { promptOrgSelection } from '../utils/prompts.js';
+import { runInkOrgPicker } from '../tui/OrgPicker.js';
+import { promptAndConfigureTools } from '../utils/configure-tools.js';
+import { releaseStdinHandoff } from '../tui/stdin.js';
+
+export async function runSwitchOrg({ profile, orgId, rewriteConfigs = true } = {}) {
+  const name = resolveProfileName(profile);
+  const auth = await readAuth(name);
+  if (!auth?.apiKey) {
+    console.log(chalk.yellow(`Not logged in (profile "${name}"). Run \`megallm login\`.`));
+    process.exit(1);
+  }
+
+  const spinner = ora('Loading organizations…').start();
+  let orgs;
+  try { orgs = await listOrgs(auth.apiKey); spinner.stop(); }
+  catch (err) { spinner.fail(err.message); process.exit(1); }
+
+  if (!orgs.length) {
+    console.log(chalk.yellow('No organizations found for this account.'));
+    return;
+  }
+
+  let target = orgId;
+  if (!target) {
+    if (process.stdout.isTTY && process.stdin.isTTY) {
+      target = await runInkOrgPicker(orgs, { currentOrgId: auth.orgId });
+    } else {
+      target = await promptOrgSelection(orgs, { defaultOrgId: auth.orgId });
+    }
+  }
+  if (!target) {
+    console.log(chalk.yellow('No org selected — nothing to do.'));
+    return;
+  }
+  const org = orgs.find(o => o.org_id === target);
+  if (!org) {
+    console.log(chalk.red(`✗ You are not a member of org "${target}".`));
+    process.exit(1);
+  }
+
+  if (org.org_id === auth.orgId) {
+    console.log(chalk.green(`Already using ${org.org_name}.`));
+    return;
+  }
+
+  // Resolve the key for the target org via the shared helper:
+  // verify-and-reuse from cache, or mint fresh when needed.
+  const keySpinner = ora('Resolving key for ' + org.org_name + '…').start();
+  let resolved;
+  try {
+    resolved = await resolveKeyForOrg({
+      auth,
+      org,
+      onProgress: (msg) => { keySpinner.text = msg; },
+    });
+    keySpinner.succeed(resolved.reused
+      ? `Reusing saved key for ${org.org_name}`
+      : `Minted a new key for ${org.org_name}`);
+  } catch (err) {
+    keySpinner.fail(err.message);
+    process.exit(1);
+  }
+
+  const { apiKey: newKey, apiKeyId: newKeyId, keyPrefix: newKeyPrefix, reused, keysByOrg } = resolved;
+
+  const updated = {
+    ...auth,
+    apiKey:    newKey,
+    apiKeyId:  newKeyId,
+    keyPrefix: newKeyPrefix,
+    orgId:     org.org_id,
+    orgName:   org.org_name,
+    keysByOrg,
+  };
+  await writeAuth(updated, name);
+  await writeState({
+    current_org_id: org.org_id,
+    current_org_name: org.org_name,
+    orgs,
+  }, name);
+
+  console.log(chalk.green(`✓ Switched to ${org.org_name}${reused ? ' (reused saved key)' : ''}`));
+  console.log(chalk.gray(`  Key: ${maskApiKey(newKey)}`));
+
+  if (rewriteConfigs) {
+    console.log('');
+    await promptAndConfigureTools(newKey, {
+      message: `Which tool would you like to update with the new ${org.org_name} key?`,
+      skipHint: `Kept tool configs as-is. Run ${chalk.bold('megallm setup')} or ${chalk.bold('megallm link <tool>')} later to apply the new ${org.org_name} key.`,
+    });
+  }
+  console.log('');
+  releaseStdinHandoff();
+}

--- a/src/commands/whoami.js
+++ b/src/commands/whoami.js
@@ -1,0 +1,32 @@
+// `megallm whoami` — show the identity behind the saved key.
+import chalk from 'chalk';
+import { readAuth, resolveProfileName, maskApiKey } from '../auth/store.js';
+import { fetchUserInfo } from '../auth/oauth.js';
+
+export async function runWhoami({ profile } = {}) {
+  const name = resolveProfileName(profile);
+  const auth = await readAuth(name);
+  if (!auth?.apiKey) {
+    console.log(chalk.yellow(`Not logged in (profile "${name}"). Run \`megallm login\`.`));
+    process.exit(1);
+  }
+  let user = auth.user;
+  try {
+    const fresh = await fetchUserInfo(auth.apiKey);
+    if (fresh) user = fresh;
+    else {
+      console.log(chalk.red('✗ Saved key is no longer valid. Run `megallm login` again.'));
+      process.exit(1);
+    }
+  } catch { /* show cached on network failure */ }
+
+  console.log(chalk.cyan('\nMegaLLM identity'));
+  console.log(chalk.gray('─'.repeat(40)));
+  console.log(`  Profile : ${chalk.white(name)}`);
+  console.log(`  Name    : ${chalk.white(user?.name || '(unknown)')}`);
+  console.log(`  Email   : ${chalk.white(user?.email || '(unknown)')}`);
+  console.log(`  Org     : ${chalk.white(auth.orgName || auth.orgId || '(default)')}`);
+  console.log(`  Scopes  : ${chalk.white((auth.scopes || []).join(' '))}`);
+  console.log(`  Key     : ${chalk.white(maskApiKey(auth.apiKey))}`);
+  console.log('');
+}

--- a/src/configurators/claude.js
+++ b/src/configurators/claude.js
@@ -1,7 +1,7 @@
 // Claude Code Configuration Module
 import path from 'path';
 import chalk from 'chalk';
-import ora from 'ora';
+import { brailleOra as ora } from '../utils/spinner.js';
 import {
   readJsonFile,
   writeJsonFile,
@@ -196,3 +196,32 @@ async function verifyClaudeConfig(configPath) {
 export { configureClaude };
 export { verifyClaudeConfig };
 export { checkExistingClaudeConfig };
+
+/**
+ * Surgically remove the MegaLLM-set keys from Claude's settings.json.
+ * Leaves any other user config intact.
+ *
+ * @returns {Promise<{ removed: boolean, configPath: string | null, reason?: string }>}
+ */
+export async function unconfigureClaude(level = 'system') {
+  const configPath = getConfigPath('claude', level);
+  if (!configPath) return { removed: false, configPath: null, reason: 'no config path' };
+  const cfg = await readJsonFile(configPath);
+  if (!cfg) return { removed: false, configPath, reason: 'no config file' };
+  if (!cfg.env) return { removed: false, configPath, reason: 'nothing to remove' };
+
+  const baseUrlIsMegaLLM = cfg.env.ANTHROPIC_BASE_URL === MEGALLM_BASE_URL;
+  const apiKeyIsMegaLLM  = typeof cfg.env.ANTHROPIC_API_KEY === 'string'
+    && cfg.env.ANTHROPIC_API_KEY.startsWith('sk-mega-');
+
+  if (!baseUrlIsMegaLLM && !apiKeyIsMegaLLM) {
+    return { removed: false, configPath, reason: 'config is not MegaLLM' };
+  }
+
+  if (baseUrlIsMegaLLM) delete cfg.env.ANTHROPIC_BASE_URL;
+  if (apiKeyIsMegaLLM)  delete cfg.env.ANTHROPIC_API_KEY;
+  if (Object.keys(cfg.env).length === 0) delete cfg.env;
+
+  await writeJsonFile(configPath, cfg, true);
+  return { removed: true, configPath };
+}

--- a/src/configurators/codex.js
+++ b/src/configurators/codex.js
@@ -1,7 +1,7 @@
 // Codex Configuration Module
 import path from 'path';
 import chalk from 'chalk';
-import ora from 'ora';
+import { brailleOra as ora } from '../utils/spinner.js';
 import {
   readTomlFile,
   writeTomlFile,
@@ -219,3 +219,29 @@ export { configureCodex };
 export { verifyCodexConfig };
 export { isWindsurf };
 export { checkExistingCodexConfig };
+
+/**
+ * Remove the megallm provider from Codex's TOML config.
+ * Only acts when `model_provider === 'megallm'` to avoid clobbering other setups.
+ *
+ * @returns {Promise<{ removed: boolean, configPath: string | null, reason?: string }>}
+ */
+export async function unconfigureCodex() {
+  const configPath = getConfigPath('codex', 'system');
+  if (!configPath) return { removed: false, configPath: null, reason: 'no config path' };
+  const cfg = await readTomlFile(configPath);
+  if (!cfg) return { removed: false, configPath, reason: 'no config file' };
+
+  const isMega = cfg.model_provider === 'megallm'
+    || cfg.model_providers?.megallm?.base_url?.includes('megallm');
+  if (!isMega) return { removed: false, configPath, reason: 'config is not MegaLLM' };
+
+  if (cfg.model_provider === 'megallm') delete cfg.model_provider;
+  if (cfg.model_providers?.megallm)     delete cfg.model_providers.megallm;
+  if (cfg.model_providers && Object.keys(cfg.model_providers).length === 0) {
+    delete cfg.model_providers;
+  }
+
+  await writeTomlFile(configPath, cfg, true);
+  return { removed: true, configPath };
+}

--- a/src/configurators/opencode.js
+++ b/src/configurators/opencode.js
@@ -1,7 +1,7 @@
 // OpenCode Configuration Module
 import path from 'path';
 import chalk from 'chalk';
-import ora from 'ora';
+import { brailleOra as ora } from '../utils/spinner.js';
 import {
   readJsonFile,
   writeJsonFile,
@@ -21,7 +21,7 @@ import { getConfigPath } from '../detectors/os.js';
  */
 async function fetchMegaLLMModels(apiKey) {
   try {
-    const response = await fetch('https://ai.megallm.io/models', {
+    const response = await fetch('https://ai.megallm.io/v1/models', {
       headers: {
         'Authorization': `Bearer ${apiKey}`
       }
@@ -283,3 +283,27 @@ async function verifyOpenCodeConfig(configPath) {
 export { configureOpenCode };
 export { verifyOpenCodeConfig };
 export { checkExistingOpenCodeConfig };
+
+/**
+ * Remove the MegaLLM-backed Anthropic provider from OpenCode's config.
+ * Acts only when `provider.anthropic.options.baseURL` points at megallm.
+ *
+ * @returns {Promise<{ removed: boolean, configPath: string | null, reason?: string }>}
+ */
+export async function unconfigureOpenCode(level = 'system') {
+  const configPath = getConfigPath('opencode', level);
+  if (!configPath) return { removed: false, configPath: null, reason: 'no config path' };
+  const cfg = await readJsonFile(configPath);
+  if (!cfg) return { removed: false, configPath, reason: 'no config file' };
+
+  const baseURL = cfg.provider?.anthropic?.options?.baseURL || '';
+  if (!baseURL.includes('megallm')) {
+    return { removed: false, configPath, reason: 'config is not MegaLLM' };
+  }
+
+  if (cfg.provider?.anthropic) delete cfg.provider.anthropic;
+  if (cfg.provider && Object.keys(cfg.provider).length === 0) delete cfg.provider;
+
+  await writeJsonFile(configPath, cfg, true);
+  return { removed: true, configPath };
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,33 @@
 import os from 'os';
 import path from 'path';
 
+// API base URL the configured tools (Claude/Codex/OpenCode) talk to.
 export const MEGALLM_BASE_URL = 'https://ai.megallm.io';
+
+// Web app URL — hosts the OAuth provider, /activate page, and dashboard.
+// Override at runtime with MEGALLM_WEB_URL for local development.
+export const MEGALLM_WEB_URL = process.env.MEGALLM_WEB_URL || 'https://megallm.io';
+
+// OAuth client_id for the MegaLLM CLI. Register the app once at
+// /dashboard/developers (public app, PKCE-only) and paste the client_id here,
+// or override per-environment with MEGALLM_CLI_CLIENT_ID.
+export const OAUTH_CLIENT_ID =
+  process.env.MEGALLM_CLI_CLIENT_ID || 'mega_pub_cli';
+
+// Scopes the CLI requests at login. All four are needed for the AWS-CLI-style
+// command surface (login, whoami, orgs, switch-org, keys list/revoke).
+export const OAUTH_SCOPES = [
+  'api:use',
+  'profile:read',
+  'keys:read',
+  'keys:manage',
+];
+
+// Where the CLI stores its credentials. Mirrors `~/.aws/`, `~/.claude/`, etc.
+export const MEGALLM_HOME = path.join(os.homedir(), '.megallm');
+export const MEGALLM_PROFILES_DIR = path.join(MEGALLM_HOME, 'profiles');
+export const MEGALLM_CONFIG_FILE = path.join(MEGALLM_HOME, 'config.json');
+export const DEFAULT_PROFILE = 'default';
 
 export const CONFIG_PATHS = {
   claude: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,7 +13,7 @@ export const MEGALLM_WEB_URL = process.env.MEGALLM_WEB_URL || 'https://megallm.i
 // /dashboard/developers (public app, PKCE-only) and paste the client_id here,
 // or override per-environment with MEGALLM_CLI_CLIENT_ID.
 export const OAUTH_CLIENT_ID =
-  process.env.MEGALLM_CLI_CLIENT_ID || 'mega_pub_cli';
+  process.env.MEGALLM_CLI_CLIENT_ID || 'mega_pub_cea180dfca';
 
 // Scopes the CLI requests at login. All four are needed for the AWS-CLI-style
 // command surface (login, whoami, orgs, switch-org, keys list/revoke).

--- a/src/tui/Hub.js
+++ b/src/tui/Hub.js
@@ -1,0 +1,150 @@
+// `npx megallm` (no args) interactive hub.
+// Loads current state once at mount (profile, identity, tools), shows it as
+// status panels, and offers a menu that dispatches to subcommand handlers.
+import {
+  html, Box, Text, render, useApp, useState, useEffect, SelectInput,
+} from './h.js';
+import { Banner, Panel, Row, ToolRow, PanelLoading } from './components.js';
+import { restoreStdinForPrompts } from './stdin.js';
+import {
+  readAuth, resolveProfileName, maskApiKey,
+} from '../auth/store.js';
+import { fetchUserInfo } from '../auth/oauth.js';
+import { checkToolsStatus } from '../detectors/tools.js';
+
+function HubScreen({ profile, onPick }) {
+  const { exit } = useApp();
+  const [auth, setAuth] = useState(undefined);     // undefined = loading; null = signed out
+  const [identity, setIdentity] = useState(undefined);
+  const [tools, setTools] = useState(undefined);
+  const [tipIdx, setTipIdx] = useState(0);
+
+  // Rotating tip footer — cycles a fresh hint every 5s. setInterval is cheap
+  // and Ink's reconciler diffs on each tick so only the footer line repaints.
+  const TIPS = [
+    'every menu item has a direct command — try "megallm --help".',
+    'switch profiles with "megallm profile use <name>".',
+    'see what\u2019s wired with "megallm doctor".',
+    'switch orgs anytime with "megallm switch-org".',
+    'list and revoke keys with "megallm keys list".',
+  ];
+  useEffect(() => {
+    const id = setInterval(() => setTipIdx(i => (i + 1) % TIPS.length), 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const a = await readAuth(profile);
+      if (cancelled) return;
+      setAuth(a);
+      if (a?.apiKey) {
+        try {
+          const u = await fetchUserInfo(a.apiKey);
+          if (!cancelled) setIdentity(u || null);
+        } catch { if (!cancelled) setIdentity(null); }
+      } else {
+        setIdentity(null);
+      }
+      try { setTools(checkToolsStatus()); } catch { setTools({}); }
+    })();
+    return () => { cancelled = true; };
+  }, [profile]);
+
+  const loading = auth === undefined || tools === undefined;
+
+  const items = !auth?.apiKey
+    ? [
+        { label: 'Sign in to MegaLLM',                            value: 'login' },
+        { label: 'Configure tools (paste a key or sign in)',      value: 'setup' },
+        { label: 'Exit',                                          value: 'exit' },
+      ]
+    : [
+        { label: 'Configure / re-configure tools',                value: 'setup' },
+        { label: 'Switch organization',                           value: 'switch-org' },
+        { label: 'Manage API keys',                               value: 'keys' },
+        { label: 'Show status',                                   value: 'status' },
+        { label: 'Run doctor (diagnose)',                         value: 'doctor' },
+        { label: 'Sign out',                                      value: 'logout' },
+        { label: 'Exit',                                          value: 'exit' },
+      ];
+
+  function handleSelect({ value }) {
+    exit();
+    onPick(value);
+  }
+
+  return html`
+    <${Box} flexDirection="column">
+      <${Banner} />
+
+      <${Panel} title="Account" color=${auth?.apiKey ? 'green' : 'yellow'} marginBottom=${1}>
+        ${loading ? html`<${PanelLoading} label="Loading account" />` : (
+          !auth?.apiKey
+            ? html`<${Text} color="gray">Not signed in. Pick "Sign in" below to begin.</>`
+            : html`
+                <${Box} flexDirection="column">
+                  <${Box} marginBottom=${0}>
+                    <${Text} color="green" bold>Welcome back, ${
+                      identity?.name || identity?.email || auth.user?.name || auth.user?.email || 'friend'
+                    }.</>
+                  </>
+                  <${Row} label="Email"     value=${identity?.email || auth.user?.email} />
+                  <${Row} label="Profile"   value=${profile} />
+                  <${Row} label="Org"       value=${auth.orgName || auth.orgId || '(default)'} />
+                  <${Row} label="Key"       value=${maskApiKey(auth.apiKey)} />
+                </>
+              `
+        )}
+      </>
+
+      <${Panel} title="Tools" color="cyan" marginBottom=${1}>
+        ${loading ? html`<${PanelLoading} label="Detecting tools" />` : html`
+          <${Box} flexDirection="column">
+            <${ToolRow} label="Claude Code" ok=${!!tools?.claude?.installed} detail=${
+              tools?.claude?.installed ? (tools.claude.configPath || 'detected') : 'not installed'
+            } />
+            <${ToolRow} label="Codex"       ok=${!!tools?.codex?.installed} detail=${
+              tools?.codex?.installed ? (tools.codex.configPath || 'detected') : 'not installed'
+            } />
+            <${ToolRow} label="OpenCode"    ok=${!!tools?.opencode?.installed} detail=${
+              tools?.opencode?.installed ? (tools.opencode.configPath || 'detected') : 'not installed'
+            } />
+          </>
+        `}
+      </>
+
+      <${Box} marginTop=${0}>
+        <${Text} color="cyan" bold>What would you like to do?</>
+      </>
+      <${SelectInput} items=${items} onSelect=${handleSelect} />
+
+      <${Box} marginTop=${1}>
+        <${Text} color="gray">Tip: ${TIPS[tipIdx]}</>
+      </>
+    </>
+  `;
+}
+
+/**
+ * Render the hub and return the user's menu pick once they confirm one.
+ *
+ * @returns {Promise<'login'|'paste'|'setup'|'switch-org'|'keys'|'status'|'logout'|'exit'>}
+ */
+export function runInkHub({ profile } = {}) {
+  const resolvedProfile = resolveProfileName(profile);
+  return new Promise((resolve) => {
+    let picked = 'exit';
+    const { waitUntilExit } = render(
+      html`<${HubScreen} profile=${resolvedProfile} onPick=${(v) => { picked = v; }} />`,
+      { exitOnCtrlC: true },
+    );
+    // Resolve only after Ink has fully unmounted AND stdin has been restored
+    // — otherwise the next inquirer prompt opens against raw-mode stdin and
+    // immediately aborts with "User force closed the prompt".
+    waitUntilExit()
+      .then(async () => { await restoreStdinForPrompts(); resolve(picked); })
+      .catch(async () => { await restoreStdinForPrompts(); resolve('exit'); });
+  });
+}

--- a/src/tui/Hub.js
+++ b/src/tui/Hub.js
@@ -66,6 +66,7 @@ function HubScreen({ profile, onPick }) {
         { label: 'Manage API keys',                               value: 'keys' },
         { label: 'Show status',                                   value: 'status' },
         { label: 'Run doctor (diagnose)',                         value: 'doctor' },
+        { label: 'Repair tool configs (doctor fix)',              value: 'doctor-fix' },
         { label: 'Sign out',                                      value: 'logout' },
         { label: 'Exit',                                          value: 'exit' },
       ];

--- a/src/tui/Login.js
+++ b/src/tui/Login.js
@@ -1,0 +1,222 @@
+// Ink screen rendered while the device-flow login is in progress.
+// Shows the verification URL + user code in a big bordered box, with a live
+// spinner that updates with seconds-left and the current state.
+import { html, Box, Text, render, useState, useEffect, useApp } from './h.js';
+import { Panel, Banner, BrailleSpinner } from './components.js';
+import { restoreStdinForPrompts } from './stdin.js';
+import { startDeviceFlow, pollForToken, fetchUserInfo, openInBrowser } from '../auth/oauth.js';
+import { listOrgs } from '../auth/api.js';
+import { writeAuth, writeState, ensureMegallmHome } from '../auth/store.js';
+import { OAUTH_CLIENT_ID, OAUTH_SCOPES, DEFAULT_PROFILE } from '../constants.js';
+import { maskApiKey } from '../auth/store.js';
+
+const STATES = {
+  REQUESTING: 'requesting',     // POST /device/code
+  WAITING:    'waiting',        // polling /token
+  FETCHING:   'fetching',       // userinfo + orgs
+  SUCCESS:    'success',
+  FAILED:     'failed',
+};
+
+function LoginScreen({ profile, onComplete }) {
+  const { exit } = useApp();
+  const [state, setState] = useState(STATES.REQUESTING);
+  const [device, setDevice] = useState(null);
+  const [secondsLeft, setSecondsLeft] = useState(0);
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
+  // Subtle 3-frame celebration on success: green → cyan → green, then settle.
+  const [shimmerColor, setShimmerColor] = useState('green');
+
+  // Drive the OAuth flow.
+  useEffect(() => {
+    let cancelled = false;
+    let abort = new AbortController();
+
+    (async () => {
+      try {
+        await ensureMegallmHome();
+
+        const dev = await startDeviceFlow({ clientId: OAUTH_CLIENT_ID, scopes: OAUTH_SCOPES });
+        if (cancelled) return;
+        setDevice(dev);
+        setSecondsLeft(dev.expires_in || 900);
+        setState(STATES.WAITING);
+
+        const url = dev.verification_uri_complete || dev.verification_uri;
+        if (url) openInBrowser(url);
+
+        const token = await pollForToken({
+          device_code: dev.device_code,
+          interval: dev.interval || 5,
+          expires_in: dev.expires_in || 900,
+          clientId: OAUTH_CLIENT_ID,
+          signal: abort.signal,
+          onTick: ({ secondsLeft: s }) => { if (!cancelled) setSecondsLeft(s); },
+        });
+        if (cancelled) return;
+
+        setState(STATES.FETCHING);
+
+        const apiKey = token.api_key;
+        let user = null;
+        try { user = await fetchUserInfo(apiKey); } catch { /* tolerate */ }
+        let orgs = [];
+        try { orgs = await listOrgs(apiKey); } catch { /* tolerate */ }
+        const activeOrg = orgs[0] || null;
+
+        const record = {
+          apiKey,
+          keyPrefix: token.key_prefix || apiKey.slice(0, 16),
+          scopes: token.scopes || OAUTH_SCOPES,
+          user: user || null,
+          orgId: activeOrg?.org_id || null,
+          orgName: activeOrg?.org_name || null,
+          clientId: OAUTH_CLIENT_ID,
+        };
+        await writeAuth(record, profile);
+        await writeState({
+          current_org_id: record.orgId,
+          current_org_name: record.orgName,
+          orgs,
+        }, profile);
+
+        if (cancelled) return;
+        setResult(record);
+        setState(STATES.SUCCESS);
+        // Brief, restrained celebration: cycle the success-line colour through
+        // green → cyan → green over ~900ms, then settle and unmount.
+        const frames = ['cyan', 'green', 'cyan', 'green'];
+        let f = 0;
+        const shimmer = setInterval(() => {
+          f += 1;
+          if (f >= frames.length) { clearInterval(shimmer); return; }
+          setShimmerColor(frames[f]);
+        }, 220);
+        setTimeout(() => { clearInterval(shimmer); exit(); onComplete?.(null, record); }, 1200);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err.message || String(err));
+        setState(STATES.FAILED);
+        setTimeout(() => { exit(); onComplete?.(err, null); }, 800);
+      }
+    })();
+
+    return () => { cancelled = true; abort.abort(); };
+  }, []);
+
+  // ── Render ──────────────────────────────────────────────────────────────
+  if (state === STATES.REQUESTING) {
+    return html`
+      <${Box} flexDirection="column" paddingY=${1}>
+        <${Box}>
+          <${BrailleSpinner} name="dna" color="cyan" />
+          <${Text}> Requesting a device code from MegaLLM…</>
+        </>
+      </>
+    `;
+  }
+
+  if (state === STATES.WAITING && device) {
+    const url = device.verification_uri || '';
+    const code = device.user_code || '';
+    return html`
+      <${Box} flexDirection="column" paddingY=${1}>
+        <${Banner} subtitle="Sign in to MegaLLM" />
+        <${Panel} title="Open this URL in your browser" color="cyan" marginBottom=${1}>
+          <${Text} color="white" bold>  ${url}</>
+        </>
+        <${Panel} title="And enter this code" color="yellow" marginBottom=${1}>
+          <${Text} color="yellow" bold>  ${code}</>
+        </>
+        <${Box}>
+          <${BrailleSpinner} name="pulse" color="cyan" />
+          <${Text}> Waiting for authorization… <${Text} color="gray">(${secondsLeft}s left)</></>
+        </>
+        <${Box} marginTop=${1}>
+          <${Text} color="gray">Press </>
+          <${Text} color="white" bold>Ctrl+C</>
+          <${Text} color="gray"> to cancel.</>
+        </>
+      </>
+    `;
+  }
+
+  if (state === STATES.FETCHING) {
+    return html`
+      <${Box} flexDirection="column" paddingY=${1}>
+        <${Box}>
+          <${Text} color="green">✓</>
+          <${Text}> Authorized</>
+        </>
+        <${Box}>
+          <${BrailleSpinner} name="braillewave" color="cyan" />
+          <${Text}> Loading account & organizations…</>
+        </>
+      </>
+    `;
+  }
+
+  if (state === STATES.SUCCESS && result) {
+    const who = result.user?.name || result.user?.email || 'MegaLLM user';
+    const where = result.orgName ? ` · org: ${result.orgName}` : '';
+    return html`
+      <${Box} flexDirection="column" paddingY=${1}>
+        <${Box}>
+          <${Text} color=${shimmerColor} bold>✓ Signed in as ${who}${where}</>
+        </>
+        <${Box}>
+          <${Text} color="gray">  Key: ${maskApiKey(result.apiKey)}  ·  Profile: ${profile}</>
+        </>
+      </>
+    `;
+  }
+
+  if (state === STATES.FAILED) {
+    return html`
+      <${Box} flexDirection="column" paddingY=${1}>
+        <${Text} color="red" bold>✗ Login failed</>
+        <${Text} color="gray">  ${error}</>
+      </>
+    `;
+  }
+
+  return null;
+}
+
+/**
+ * Render the Ink login screen. Resolves with the saved auth record on success.
+ *
+ * @param {{ profile?: string }} opts
+ * @returns {Promise<object>}
+ */
+export function runInkLogin({ profile = DEFAULT_PROFILE } = {}) {
+  return new Promise((resolve, reject) => {
+    // Stash the result locally; the outer promise only settles once Ink has
+    // fully unmounted (waitUntilExit) AND stdin has been restored. Resolving
+    // earlier would race with Ink's teardown and leave raw-mode listeners
+    // attached, which then cause @inquirer/prompts to abort with
+    // "User force closed the prompt".
+    let savedErr = null;
+    let savedRec = null;
+
+    const { waitUntilExit } = render(
+      html`<${LoginScreen} profile=${profile} onComplete=${(err, rec) => {
+        savedErr = err; savedRec = rec;
+      }} />`,
+      { exitOnCtrlC: true },
+    );
+
+    waitUntilExit()
+      .then(async () => {
+        await restoreStdinForPrompts();
+        if (savedErr) reject(savedErr);
+        else if (savedRec) resolve(savedRec);
+        else reject(new Error('Login cancelled'));
+      })
+      .catch(async (err) => {
+        await restoreStdinForPrompts();
+        reject(savedErr || err);
+      });
+  });
+}

--- a/src/tui/Login.js
+++ b/src/tui/Login.js
@@ -1,27 +1,39 @@
-// Ink screen rendered while the device-flow login is in progress.
-// Shows the verification URL + user code in a big bordered box, with a live
-// spinner that updates with seconds-left and the current state.
+// Ink screen rendered while the OAuth login is in progress.
+//
+// Default flow is RFC 8252 §7.3 loopback (CLI binds 127.0.0.1, opens the
+// consent screen, exchanges the auth code on callback). Falls back to the
+// device-code flow when the env clearly has no desktop browser (SSH boxes,
+// headless Linux), or when the user passes --no-browser.
 import { html, Box, Text, render, useState, useEffect, useApp } from './h.js';
 import { Panel, Banner, BrailleSpinner } from './components.js';
 import { restoreStdinForPrompts } from './stdin.js';
-import { startDeviceFlow, pollForToken, fetchUserInfo, openInBrowser } from '../auth/oauth.js';
+import {
+  startDeviceFlow,
+  pollForToken,
+  fetchUserInfo,
+  openInBrowser,
+  loopbackLogin,
+  canUseLoopback,
+} from '../auth/oauth.js';
 import { listOrgs } from '../auth/api.js';
 import { writeAuth, writeState, ensureMegallmHome } from '../auth/store.js';
 import { OAUTH_CLIENT_ID, OAUTH_SCOPES, DEFAULT_PROFILE } from '../constants.js';
 import { maskApiKey } from '../auth/store.js';
 
 const STATES = {
-  REQUESTING: 'requesting',     // POST /device/code
-  WAITING:    'waiting',        // polling /token
+  STARTING:   'starting',       // deciding which flow + bootstrapping
+  AWAITING:   'awaiting',       // browser open, waiting for callback / approval
   FETCHING:   'fetching',       // userinfo + orgs
   SUCCESS:    'success',
   FAILED:     'failed',
 };
 
-function LoginScreen({ profile, onComplete }) {
+function LoginScreen({ profile, onComplete, forceDeviceFlow = false }) {
   const { exit } = useApp();
-  const [state, setState] = useState(STATES.REQUESTING);
-  const [device, setDevice] = useState(null);
+  const [state, setState] = useState(STATES.STARTING);
+  const [flow, setFlow] = useState(null); // 'loopback' | 'device'
+  const [device, setDevice] = useState(null);   // device-flow data
+  const [authUrl, setAuthUrl] = useState('');   // loopback flow URL (fallback)
   const [secondsLeft, setSecondsLeft] = useState(0);
   const [result, setResult] = useState(null);
   const [error, setError] = useState(null);
@@ -37,23 +49,42 @@ function LoginScreen({ profile, onComplete }) {
       try {
         await ensureMegallmHome();
 
-        const dev = await startDeviceFlow({ clientId: OAUTH_CLIENT_ID, scopes: OAUTH_SCOPES });
-        if (cancelled) return;
-        setDevice(dev);
-        setSecondsLeft(dev.expires_in || 900);
-        setState(STATES.WAITING);
+        const useLoopback = !forceDeviceFlow && canUseLoopback();
+        setFlow(useLoopback ? 'loopback' : 'device');
 
-        const url = dev.verification_uri_complete || dev.verification_uri;
-        if (url) openInBrowser(url);
+        let token;
+        if (useLoopback) {
+          // Loopback: server starts, browser opens, we wait for the redirect.
+          setState(STATES.AWAITING);
+          token = await loopbackLogin({
+            clientId: OAUTH_CLIENT_ID,
+            scopes: OAUTH_SCOPES,
+            signal: abort.signal,
+            onAuthorizeUrl: (u) => { if (!cancelled) setAuthUrl(u); },
+          });
+        } else {
+          // Device flow: show user_code + URL, poll until approved.
+          const dev = await startDeviceFlow({
+            clientId: OAUTH_CLIENT_ID,
+            scopes: OAUTH_SCOPES,
+          });
+          if (cancelled) return;
+          setDevice(dev);
+          setSecondsLeft(dev.expires_in || 900);
+          setState(STATES.AWAITING);
 
-        const token = await pollForToken({
-          device_code: dev.device_code,
-          interval: dev.interval || 5,
-          expires_in: dev.expires_in || 900,
-          clientId: OAUTH_CLIENT_ID,
-          signal: abort.signal,
-          onTick: ({ secondsLeft: s }) => { if (!cancelled) setSecondsLeft(s); },
-        });
+          const url = dev.verification_uri_complete || dev.verification_uri;
+          if (url) openInBrowser(url);
+
+          token = await pollForToken({
+            device_code: dev.device_code,
+            interval: dev.interval || 5,
+            expires_in: dev.expires_in || 900,
+            clientId: OAUTH_CLIENT_ID,
+            signal: abort.signal,
+            onTick: ({ secondsLeft: s }) => { if (!cancelled) setSecondsLeft(s); },
+          });
+        }
         if (cancelled) return;
 
         setState(STATES.FETCHING);
@@ -106,18 +137,39 @@ function LoginScreen({ profile, onComplete }) {
   }, []);
 
   // ── Render ──────────────────────────────────────────────────────────────
-  if (state === STATES.REQUESTING) {
+  if (state === STATES.STARTING) {
     return html`
       <${Box} flexDirection="column" paddingY=${1}>
         <${Box}>
           <${BrailleSpinner} name="dna" color="cyan" />
-          <${Text}> Requesting a device code from MegaLLM…</>
+          <${Text}> Starting MegaLLM login…</>
         </>
       </>
     `;
   }
 
-  if (state === STATES.WAITING && device) {
+  if (state === STATES.AWAITING && flow === 'loopback') {
+    return html`
+      <${Box} flexDirection="column" paddingY=${1}>
+        <${Banner} subtitle="Sign in to MegaLLM" />
+        <${Panel} title="Approve this login in your browser" color="cyan" marginBottom=${1}>
+          <${Text} color="gray">  A new browser tab should have opened. If not, paste this URL:</>
+          <${Text} color="white" bold>  ${authUrl}</>
+        </>
+        <${Box}>
+          <${BrailleSpinner} name="pulse" color="cyan" />
+          <${Text}> Waiting for browser approval…</>
+        </>
+        <${Box} marginTop=${1}>
+          <${Text} color="gray">Press </>
+          <${Text} color="white" bold>Ctrl+C</>
+          <${Text} color="gray"> to cancel.</>
+        </>
+      </>
+    `;
+  }
+
+  if (state === STATES.AWAITING && flow === 'device' && device) {
     const url = device.verification_uri || '';
     const code = device.user_code || '';
     return html`
@@ -187,10 +239,10 @@ function LoginScreen({ profile, onComplete }) {
 /**
  * Render the Ink login screen. Resolves with the saved auth record on success.
  *
- * @param {{ profile?: string }} opts
+ * @param {{ profile?: string, forceDeviceFlow?: boolean }} opts
  * @returns {Promise<object>}
  */
-export function runInkLogin({ profile = DEFAULT_PROFILE } = {}) {
+export function runInkLogin({ profile = DEFAULT_PROFILE, forceDeviceFlow = false } = {}) {
   return new Promise((resolve, reject) => {
     // Stash the result locally; the outer promise only settles once Ink has
     // fully unmounted (waitUntilExit) AND stdin has been restored. Resolving
@@ -201,9 +253,11 @@ export function runInkLogin({ profile = DEFAULT_PROFILE } = {}) {
     let savedRec = null;
 
     const { waitUntilExit } = render(
-      html`<${LoginScreen} profile=${profile} onComplete=${(err, rec) => {
-        savedErr = err; savedRec = rec;
-      }} />`,
+      html`<${LoginScreen}
+        profile=${profile}
+        forceDeviceFlow=${forceDeviceFlow}
+        onComplete=${(err, rec) => { savedErr = err; savedRec = rec; }}
+      />`,
       { exitOnCtrlC: true },
     );
 

--- a/src/tui/OrgPicker.js
+++ b/src/tui/OrgPicker.js
@@ -1,0 +1,57 @@
+// Ink-rendered org picker.  Used by `megallm switch-org` (no argument) and
+// by the hub when the user picks "Switch organization".
+import { html, Box, Text, render, useApp, useState, useEffect, SelectInput } from './h.js';
+import { Banner } from './components.js';
+import { restoreStdinForPrompts } from './stdin.js';
+
+function OrgPickerScreen({ orgs, currentOrgId, onPick }) {
+  const { exit } = useApp();
+  const [picked, setPicked] = useState(null);
+
+  const items = orgs.map(o => ({
+    label: `${o.org_id === currentOrgId ? '★ ' : '  '}${o.org_name}` +
+           (o.role ? `  (${o.role})` : ''),
+    value: o.org_id,
+  }));
+
+  function handleSelect({ value }) {
+    setPicked(value);
+    exit();
+    onPick(value);
+  }
+
+  return html`
+    <${Box} flexDirection="column">
+      <${Banner} subtitle="Pick the organization you want to use" />
+      <${Box} marginBottom=${1}>
+        <${Text} color="cyan" bold>Organizations</>
+      </>
+      <${SelectInput} items=${items} onSelect=${handleSelect} />
+      <${Box} marginTop=${1}>
+        <${Text} color="gray">★ marks the currently active org. Press </>
+        <${Text} color="white" bold>Ctrl+C</>
+        <${Text} color="gray"> to cancel.</>
+      </>
+    </>
+  `;
+}
+
+/**
+ * @param {Array<{org_id:string, org_name:string, role?:string}>} orgs
+ * @param {{ currentOrgId?: string }} [opts]
+ * @returns {Promise<string|null>} the selected `org_id`, or null on cancel
+ */
+export function runInkOrgPicker(orgs, { currentOrgId } = {}) {
+  return new Promise((resolve) => {
+    let picked = null;
+    const { waitUntilExit } = render(
+      html`<${OrgPickerScreen} orgs=${orgs} currentOrgId=${currentOrgId} onPick=${(v) => { picked = v; }} />`,
+      { exitOnCtrlC: true },
+    );
+    // Resolve only after Ink has fully unmounted and stdin has been restored,
+    // otherwise the next inquirer prompt aborts with "User force closed".
+    waitUntilExit()
+      .then(async () => { await restoreStdinForPrompts(); resolve(picked); })
+      .catch(async () => { await restoreStdinForPrompts(); resolve(null); });
+  });
+}

--- a/src/tui/components.js
+++ b/src/tui/components.js
@@ -1,0 +1,129 @@
+// Reusable Ink building blocks shared across the hub, login, and wizard screens.
+import gradient from 'gradient-string';
+import spinners from 'unicode-animations';
+import { html, Box, Text, useState, useEffect, useMemo } from './h.js';
+import { buildWordmarkGrid, renderShimmerFrame, shimmerSpan } from './shimmer.js';
+
+// Tasteful 2-stop gradient — stays in the cool blue/cyan family so the banner
+// reads as "premium tooling" rather than "rainbow toy".  Falls back to plain
+// cyan on terminals that can't render truecolor (gradient-string handles that).
+const BRAND_GRADIENT = gradient(['#22d3ee', '#3b82f6']); // cyan-400 → blue-500
+
+// Build the plain-text "MegaLLM" wordmark grid once at module-load. The
+// `<ShimmerWordmark/>` component re-colours it per frame for the diagonal
+// sweep, so we don't bake any colour in here.
+const WORDMARK_GRID = buildWordmarkGrid('MegaLLM');
+
+// Width of the wordmark (used to size the rule under the banner).
+const WORDMARK_W = 70;
+
+/**
+ * Animated cfonts wordmark with a translucent diagonal shimmer that travels
+ * top-left → bottom-right while the base colour stays brand-blue.
+ */
+export function ShimmerWordmark() {
+  const span = useMemo(() => shimmerSpan(WORDMARK_GRID), []);
+  const [pos, setPos] = useState(span.start);
+  useEffect(() => {
+    const t = setInterval(() => {
+      setPos((p) => (p + span.step > span.end ? span.start : p + span.step));
+    }, span.intervalMs);
+    return () => clearInterval(t);
+  }, [span]);
+  const lines = renderShimmerFrame(WORDMARK_GRID, pos);
+  return html`
+    <${Box} flexDirection="column">
+      ${lines.map((line, i) => html`<${Text} key=${i}>${line}</>`)}
+    </>
+  `;
+}
+
+/**
+ * Animated braille loading indicator driven by `unicode-animations`.
+ * Default `braille` spinner is a 1-char drop-in for `<Spinner type="dots" />`.
+ * Pass `name="dna" | "pulse" | "braillewave" | …` for richer animations.
+ */
+export function BrailleSpinner({ name = 'braille', color = 'cyan' }) {
+  const sp = spinners[name] || spinners.braille;
+  const [frame, setFrame] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => setFrame((f) => (f + 1) % sp.frames.length), sp.interval);
+    return () => clearInterval(t);
+  }, [name]);
+  return html`<${Text} color=${color}>${sp.frames[frame]}</>`;
+}
+
+/** Compact, themed panel with a coloured title bar. */
+export function Panel({ title, color = 'cyan', children, marginBottom = 0 }) {
+  return html`
+    <${Box}
+      flexDirection="column"
+      borderStyle="round"
+      borderColor=${color}
+      paddingX=${1}
+      marginBottom=${marginBottom}
+    >
+      ${title
+        ? html`<${Box} marginBottom=${0}><${Text} bold color=${color}>${title}</></>`
+        : null}
+      ${children}
+    </>
+  `;
+}
+
+/** A two-column "label : value" row used in status / whoami / hub panels. */
+export function Row({ label, value, valueColor = 'white', labelWidth = 14 }) {
+  return html`
+    <${Box}>
+      <${Box} width=${labelWidth}>
+        <${Text} color="gray">${label}</>
+      </>
+      <${Text} color=${valueColor}>${value || '—'}</>
+    </>
+  `;
+}
+
+/** ✓ / ✗ tool-status line for the tools panel. */
+export function ToolRow({ label, ok, detail }) {
+  return html`
+    <${Box}>
+      <${Text} color=${ok ? 'green' : 'gray'}>${ok ? '✓' : '✗'} </>
+      <${Box} width=${14}>
+        <${Text} color=${ok ? 'white' : 'gray'}>${label}</>
+      </>
+      <${Text} color="gray">${detail || (ok ? 'configured' : 'not configured')}</>
+    </>
+  `;
+}
+
+/**
+ * Big branded welcome banner: animated shimmer wordmark, a thick gradient
+ * rule, and a two-row tagline.
+ */
+export function Banner({
+  subtitle = 'Sign in once. Use Claude Code, Codex, OpenCode.',
+  hint = 'Docs at megallm.io  ·  /help inside any tool',
+} = {}) {
+  const rule = BRAND_GRADIENT('━'.repeat(WORDMARK_W));
+  return html`
+    <${Box} flexDirection="column" marginBottom=${1}>
+      <${ShimmerWordmark} />
+      <${Text}>${rule}</>
+      <${Box} marginTop=${1}>
+        <${Text} color="cyan" bold> ✻  </>
+        <${Text} bold>${subtitle}</>
+      </>
+      <${Box}>
+        <${Text} color="gray">    ${hint}</>
+      </>
+    </>
+  `;
+}
+
+/** Loading skeleton for sections that haven't resolved yet. */
+export function PanelLoading({ label }) {
+  return html`<${Text} color="gray">  ${label}…</>`;
+}
+
+
+

--- a/src/tui/components.js
+++ b/src/tui/components.js
@@ -102,7 +102,7 @@ export function ToolRow({ label, ok, detail }) {
  */
 export function Banner({
   subtitle = 'Sign in once. Use Claude Code, Codex, OpenCode.',
-  hint = 'Docs at megallm.io  ·  /help inside any tool',
+  hint = 'Docs at docs.megallm.io  ·  /help inside any tool',
 } = {}) {
   const rule = BRAND_GRADIENT('━'.repeat(WORDMARK_W));
   return html`
@@ -124,6 +124,3 @@ export function Banner({
 export function PanelLoading({ label }) {
   return html`<${Text} color="gray">  ${label}…</>`;
 }
-
-
-

--- a/src/tui/h.js
+++ b/src/tui/h.js
@@ -1,0 +1,28 @@
+// Tiny ergonomic wrapper around `htm` + `react` so we can author Ink screens
+// without a JSX build step. Re-exports the Ink primitives we use most often
+// so individual screens only need to import from here.
+import { createElement } from 'react';
+import htmFactory from 'htm';
+
+export {
+  Box,
+  Text,
+  Newline,
+  useApp,
+  useInput,
+  useFocus,
+  useStdin,
+  render,
+} from 'ink';
+
+export { default as SelectInput } from 'ink-select-input';
+export { default as Spinner } from 'ink-spinner';
+
+export { useState, useEffect, useMemo, useCallback } from 'react';
+
+/**
+ * Tagged-template renderer. Usage:
+ *   import { html, Box, Text } from './h.js';
+ *   const App = () => html`<${Box}><${Text} color="cyan">hi</></>`;
+ */
+export const html = htmFactory.bind(createElement);

--- a/src/tui/shimmer.js
+++ b/src/tui/shimmer.js
@@ -1,0 +1,128 @@
+// Diagonal shimmer animation over the cfonts "MegaLLM" wordmark.
+//
+// Strategy: render the wordmark once with cfonts as plain text (white-only),
+// strip the ANSI to get a 2D char grid, then per frame build a coloured
+// version of each line where the base colour is brand-blue and a translucent
+// "stripe" — diagonal index `col + row*2 - shimmerPos` within ±STRIPE/2 —
+// brightens those characters toward white. Negative-space chars are skipped
+// so only the block letters animate.
+
+import cfonts from 'cfonts';
+
+// Brand blue (always-on) and the highlight the stripe sweeps in.
+const BASE      = [59, 130, 246];   // tailwind blue-500
+const HIGHLIGHT = [212, 240, 255];  // cool-white shimmer
+
+const STRIPE = 16;            // width of the bright band
+const FRAME_STEP = 2;         // chars-of-diagonal per frame
+const FRAME_MS = 55;          // ms per frame
+
+const ANSI_RE = /\x1B\[[0-9;]*m/g;
+const stripAnsi = (s) => s.replace(ANSI_RE, '');
+const ansi = ([r, g, b]) => `\x1B[38;2;${r};${g};${b}m`;
+const RESET = '\x1B[0m';
+
+function lerp(a, b, t) {
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * t),
+    Math.round(a[1] + (b[1] - a[1]) * t),
+    Math.round(a[2] + (b[2] - a[2]) * t),
+  ];
+}
+
+/** Render the wordmark and return it as an array of plain-text lines. */
+export function buildWordmarkGrid(text = 'MegaLLM') {
+  const raw = cfonts.render(text, {
+    font: 'block',
+    colors: ['white'],
+    align: 'left',
+    space: false,
+    lineHeight: 0,
+    env: 'node',
+  });
+  // Drop the leading blank line cfonts emits.
+  return raw.array
+    .map(stripAnsi)
+    .filter((l, i, arr) => !(i === 0 && l.trim() === '') && !(i === arr.length - 1 && l.trim() === ''));
+}
+
+/** Total diagonal travel distance from off-screen-left to off-screen-right. */
+export function shimmerSpan(grid) {
+  const cols = Math.max(...grid.map((l) => l.length));
+  const rows = grid.length;
+  return {
+    start: -STRIPE,
+    end:   cols + rows * 2 + STRIPE,
+    rows,
+    cols,
+    step: FRAME_STEP,
+    intervalMs: FRAME_MS,
+  };
+}
+
+/**
+ * Build the ANSI-coloured version of `grid` for a given shimmer position.
+ * Returns one string per row.
+ */
+export function renderShimmerFrame(grid, shimmerPos) {
+  return grid.map((line, row) => {
+    let out = '';
+    let lastKey = null;
+    for (let col = 0; col < line.length; col++) {
+      const ch = line[col];
+      if (ch === ' ' || ch === '\t') {
+        if (lastKey !== null) { out += RESET; lastKey = null; }
+        out += ch;
+        continue;
+      }
+      // Diagonal index: row*2 keeps the slope visually 45° given that block
+      // characters are about twice as tall as wide.
+      const d = col + row * 2 - shimmerPos;
+      let color = BASE;
+      if (d >= 0 && d <= STRIPE) {
+        // Bell curve across the stripe so edges fade nicely.
+        const t = 1 - Math.abs((d - STRIPE / 2) / (STRIPE / 2));
+        color = lerp(BASE, HIGHLIGHT, t);
+      }
+      const key = color[0] * 65536 + color[1] * 256 + color[2];
+      if (key !== lastKey) {
+        out += ansi(color);
+        lastKey = key;
+      }
+      out += ch;
+    }
+    return out + RESET;
+  });
+}
+
+/**
+ * Drive a one-shot shimmer pass on stdout (used by the wizard's banner).
+ * Resolves once the stripe has crossed the wordmark and the final all-blue
+ * frame is on screen. Non-TTY environments fall back to a static frame.
+ */
+export async function playShimmerOnce(grid, { passes = 1 } = {}) {
+  if (!process.stdout.isTTY) {
+    process.stdout.write(grid.map((l) => ansi(BASE) + l + RESET).join('\n') + '\n');
+    return;
+  }
+  const span = shimmerSpan(grid);
+  const lineCount = grid.length;
+
+  // Reserve `lineCount` blank lines we'll overwrite each frame.
+  process.stdout.write('\n'.repeat(lineCount));
+
+  const writeFrame = (pos) => {
+    const lines = renderShimmerFrame(grid, pos);
+    process.stdout.write(`\x1B[${lineCount}A`); // cursor up
+    for (const l of lines) process.stdout.write('\r' + l + '\x1B[K\n');
+  };
+
+  for (let p = 0; p < passes; p++) {
+    for (let pos = span.start; pos <= span.end; pos += span.step) {
+      writeFrame(pos);
+      await new Promise((r) => setTimeout(r, span.intervalMs));
+    }
+  }
+  // Settle on a clean all-blue frame.
+  writeFrame(span.end + 999);
+}

--- a/src/tui/stdin.js
+++ b/src/tui/stdin.js
@@ -1,0 +1,53 @@
+// Hand stdin back to plain readline-style prompts (e.g. @inquirer/prompts)
+// after an Ink screen has unmounted.
+//
+// Two real issues we have to work around:
+//
+// 1. Ink switches the TTY into raw mode and adds 'data' / 'keypress'
+//    listeners.  Even after `useApp().exit()` resolves `waitUntilExit`, those
+//    handlers can linger for a microtask.
+//
+// 2. More importantly, between Ink's unmount and the moment a follow-up
+//    `@inquirer/prompts.confirm` actually attaches its readline interface,
+//    Node's event loop can briefly have no pending work.  When that happens
+//    Node fires `process.emit('exit')`, which the `signal-exit` package
+//    (used by both Ink AND @inquirer/core) interprets as a real shutdown and
+//    rejects every active prompt with "User force closed the prompt with 0 null".
+//
+// To prevent that, we run a no-op heartbeat interval that keeps the loop
+// alive across the handoff.  Callers can release it with `releaseStdinHandoff`.
+let heartbeat = null;
+
+export function restoreStdinForPrompts() {
+  return new Promise((resolve) => {
+    try {
+      if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
+        process.stdin.setRawMode(false);
+      }
+      // Strip Ink's lingering keystroke listeners. We deliberately do NOT
+      // pause stdin; inquirer needs it open and flowing.
+      process.stdin.removeAllListeners('data');
+      process.stdin.removeAllListeners('keypress');
+      process.stdin.removeAllListeners('readable');
+      process.stdin.resume();
+    } catch { /* not a TTY — nothing to restore */ }
+
+    // Heartbeat keeps the event loop pinned so 'exit' isn't spuriously
+    // emitted during the Ink → inquirer transition. The first inquirer prompt
+    // (or anything else holding stdin open) supersedes it; we just need to
+    // bridge the gap. The interval is short-lived in practice — once the
+    // caller suspends on a prompt, this fires harmlessly until released.
+    if (!heartbeat) heartbeat = setInterval(() => {}, 1000);
+
+    // One event-loop turn lets Ink's teardown finish before we hand off.
+    setTimeout(resolve, 50);
+  });
+}
+
+/** Stop the keep-alive heartbeat (call once your CLI is fully done). */
+export function releaseStdinHandoff() {
+  if (heartbeat) {
+    clearInterval(heartbeat);
+    heartbeat = null;
+  }
+}

--- a/src/utils/configure-tools.js
+++ b/src/utils/configure-tools.js
@@ -1,0 +1,89 @@
+// Shared tool-picker + apply step used by `megallm login` and `megallm
+// switch-org`. Detects installed AI tools, asks the user which one(s) to
+// (re)configure with a given API key (with an "All" + "Skip" choice), runs
+// the configurators, and updates the relevant env vars.
+import chalk from 'chalk';
+import { select } from '@inquirer/prompts';
+import { configureClaude } from '../configurators/claude.js';
+import { configureCodex } from '../configurators/codex.js';
+import { configureOpenCode } from '../configurators/opencode.js';
+import { checkToolsStatus } from '../detectors/tools.js';
+import { setEnvironmentVariable } from './shell.js';
+import { MEGALLM_BASE_URL } from '../constants.js';
+
+/**
+ * @param {string} apiKey  The MegaLLM API key to write into tool configs.
+ * @param {object} [opts]
+ * @param {string} [opts.message]    Prompt text shown to the user.
+ * @param {boolean} [opts.updateEnv] When true (default) refresh the
+ *   ANTHROPIC_BASE_URL / ANTHROPIC_API_KEY / MEGALLM_API_KEY env vars after
+ *   a successful configure.
+ * @param {string}  [opts.skipHint]  Override the message printed when the
+ *   user picks "Skip".
+ * @returns {Promise<{ picked: string, results: Array<{ tool: string, ok: boolean, error?: string }> }>}
+ *   `picked` is one of the installed tool keys / `'all'` / `'skip'`.
+ */
+export async function promptAndConfigureTools(apiKey, opts = {}) {
+  const message = opts.message
+    || 'Which tool would you like to configure with this key?';
+  const updateEnv = opts.updateEnv !== false;
+
+  const tools = checkToolsStatus();
+  const installed = [];
+  if (tools.claude?.installed)   installed.push({ key: 'claude',   label: 'Claude Code', fn: () => configureClaude(apiKey, 'system') });
+  if (tools.codex?.installed)    installed.push({ key: 'codex',    label: 'Codex',       fn: () => configureCodex(apiKey, 'system') });
+  if (tools.opencode?.installed) installed.push({ key: 'opencode', label: 'OpenCode',    fn: () => configureOpenCode(apiKey, 'system') });
+
+  if (installed.length === 0) {
+    console.log(chalk.gray('\nNo AI tools detected — nothing to configure.'));
+    console.log(chalk.gray(`Run ${chalk.bold('megallm setup')} once you install Claude Code, Codex, or OpenCode.\n`));
+    return { picked: 'skip', results: [] };
+  }
+
+  const choices = installed.map((t) => ({ name: t.label, value: t.key }));
+  if (installed.length > 1) {
+    choices.push({
+      name: `All (${installed.map((t) => t.label).join(', ')})`,
+      value: 'all',
+    });
+  }
+  choices.push({ name: 'Skip — keep existing tool configs as-is', value: 'skip' });
+
+  const picked = await select({
+    message,
+    choices,
+    default: installed.length > 1 ? 'all' : installed[0].key,
+  });
+
+  if (picked === 'skip') {
+    const hint = opts.skipHint
+      || `Kept tool configs as-is. Run ${chalk.bold('megallm setup')} or ${chalk.bold('megallm link <tool>')} later to apply.`;
+    console.log(chalk.gray('\n' + hint + '\n'));
+    return { picked, results: [] };
+  }
+
+  const targets = picked === 'all' ? installed : installed.filter((t) => t.key === picked);
+  console.log(chalk.cyan('\nUpdating tool configs…'));
+  const settled = await Promise.allSettled(targets.map((t) => t.fn()));
+  const results = settled.map((r, i) => {
+    const target = targets[i];
+    if (r.status === 'fulfilled' && r.value) {
+      console.log(chalk.green(`  ✓ ${target.label}`));
+      return { tool: target.key, ok: true };
+    }
+    if (r.status === 'fulfilled') {
+      console.log(chalk.gray(`  • ${target.label} skipped`));
+      return { tool: target.key, ok: false };
+    }
+    console.log(chalk.red(`  ✗ ${target.label}: ${r.reason?.message || 'failed'}`));
+    return { tool: target.key, ok: false, error: r.reason?.message || 'failed' };
+  });
+
+  if (updateEnv) {
+    setEnvironmentVariable('ANTHROPIC_BASE_URL', MEGALLM_BASE_URL, true);
+    setEnvironmentVariable('ANTHROPIC_API_KEY', apiKey, true);
+    setEnvironmentVariable('MEGALLM_API_KEY', apiKey, true);
+  }
+
+  return { picked, results };
+}

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -1,7 +1,7 @@
 // Tool Installation Module
 import { execSync } from 'child_process';
 import chalk from 'chalk';
-import ora from 'ora';
+import { brailleOra as ora } from './spinner.js';
 import { confirm } from '@inquirer/prompts';
 
 async function installClaudeCode() {

--- a/src/utils/prompts.js
+++ b/src/utils/prompts.js
@@ -2,6 +2,7 @@
 import { select, input, confirm, password } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { TOOLS, SETUP_LEVELS } from '../constants.js';
+import { maskApiKey } from '../auth/store.js';
 
 /**
  * Prompt the user to choose which tool(s) to configure.
@@ -23,7 +24,8 @@ export async function promptToolSelection(availableTools) {
         { name: 'Claude Code', value: 'claude' },
         { name: 'Codex', value: 'codex' },
         { name: 'Open Code', value: 'opencode' },
-        { name: 'All', value: 'all' }
+        { name: 'All', value: 'all' },
+        { name: 'Skip — exit setup', value: 'skip' },
       ]
     });
 
@@ -40,6 +42,7 @@ export async function promptToolSelection(availableTools) {
   } else if (availableTools.length == 3) {
     choices.push({ name: 'Configure All', value: 'all' });
   }
+  choices.push({ name: 'Skip — exit setup', value: 'skip' });
 
   const selectedTool = await select({
     message: 'Which tool would you like to configure?',
@@ -246,4 +249,85 @@ export async function promptStatuslineSetup() {
   });
 
   return wantsStatusline;
+}
+
+/**
+ * Choose how to obtain a MegaLLM API key for the wizard:
+ *   - 'login'    : run the OAuth device flow in the browser
+ *   - 'paste'    : paste an existing key
+ *   - 'existing' : reuse a saved CLI session (only offered when one exists)
+ *
+ * @param {{ hasExistingSession?: boolean, sessionLabel?: string }} opts
+ */
+export async function promptAuthMethod({ hasExistingSession = false, sessionLabel = '' } = {}) {
+  const choices = [
+    {
+      name: '🔐  Login with browser (recommended)',
+      value: 'login',
+      description: 'Sign in to megallm.io and we will create a key for you'
+    },
+    {
+      name: '🔑  Paste an existing API key',
+      value: 'paste',
+      description: 'Use a key you already created in the dashboard'
+    },
+  ];
+  if (hasExistingSession) {
+    choices.unshift({
+      name: `✅  Use saved session${sessionLabel ? ` (${sessionLabel})` : ''}`,
+      value: 'existing',
+      description: 'Reuse the credentials saved in ~/.megallm'
+    });
+  }
+
+  return select({
+    message: 'How would you like to authenticate?',
+    choices,
+    default: hasExistingSession ? 'existing' : 'login',
+  });
+}
+
+/**
+ * Pick an org from a list returned by /api/oauth/orgs.
+ * Returns the chosen `org_id` (string) or null if the user cancels.
+ */
+export async function promptOrgSelection(orgs, { defaultOrgId } = {}) {
+  if (!orgs || orgs.length === 0) return null;
+  if (orgs.length === 1) return orgs[0].org_id;
+
+  const choices = orgs.map(o => ({
+    name: o.role ? `${o.org_name}  ${chalk.gray('· ' + o.role)}` : o.org_name,
+    value: o.org_id,
+  }));
+
+  return select({
+    message: 'Choose an organization:',
+    choices,
+    default: defaultOrgId || choices[0].value,
+  });
+}
+
+/**
+ * Plain-paste API key prompt (no browser). Used when the user picks 'paste'
+ * in promptAuthMethod, and as the fallback for environments without a browser.
+ */
+export async function promptApiKeyPaste(toolName = '') {
+  const apiKey = await password({
+    message: `Paste your MegaLLM API key${toolName ? ` for ${toolName}` : ''}:`,
+    mask: '*',
+    validate: (value) => {
+      if (!value || value.trim().length === 0) return 'API key is required';
+      if (value.length < 20) return 'API key seems too short. Please check and try again.';
+      return true;
+    },
+  });
+  return apiKey.trim();
+}
+
+/** Display a one-line "signed in as …" banner after a successful login. */
+export function printIdentityBanner({ user, orgName, apiKey }) {
+  const who = user?.name || user?.email || 'MegaLLM user';
+  const where = orgName ? chalk.gray(` · org: ${orgName}`) : '';
+  const key = apiKey ? chalk.gray(` · key: ${maskApiKey(apiKey)}`) : '';
+  console.log(chalk.green(`\n✓ Signed in as ${chalk.bold(who)}${where}${key}`));
 }

--- a/src/utils/shell.js
+++ b/src/utils/shell.js
@@ -128,6 +128,42 @@ function getEnvironmentVariable(key) {
   return process.env[key] || null;
 }
 
+/**
+ * Read the persisted value of an env var from the user's shell rc file.
+ * Looks for bash/zsh `export NAME=VALUE` and fish `set -gx NAME VALUE`.
+ * Returns the unquoted value, or null when the var isn't persisted.
+ *
+ * @param {string} key
+ * @returns {string | null}
+ */
+function readPersistedEnvVar(key) {
+  if (os.platform() === 'win32') return null;
+  try {
+    const file = getShellConfigFile();
+    if (!fs.existsSync(file)) return null;
+    const content = fs.readFileSync(file, 'utf8');
+    const escaped = key.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+    // Last match wins — matches setEnvironmentVariable's "replace in place"
+    // behaviour and tolerates duplicates.
+    const bashRe = new RegExp(`^\\s*export\\s+${escaped}=(.+?)\\s*$`, 'gm');
+    const fishRe = new RegExp(`^\\s*set\\s+-gx\\s+${escaped}\\s+(.+?)\\s*$`, 'gm');
+    let last = null;
+    for (const re of [bashRe, fishRe]) {
+      let m;
+      while ((m = re.exec(content)) !== null) last = m[1];
+    }
+    if (last == null) return null;
+    let v = last.trim();
+    if ((v.startsWith('"') && v.endsWith('"')) ||
+        (v.startsWith("'") && v.endsWith("'"))) {
+      v = v.slice(1, -1);
+    }
+    return v;
+  } catch {
+    return null;
+  }
+}
+
 function validateApiKey(apiKey) {
   // Basic validation for API key format
   if (!apiKey || apiKey.trim().length === 0) {
@@ -154,5 +190,6 @@ function getLastNCharacters(str, n = 20) {
 export { reloadShell };
 export { setEnvironmentVariable };
 export { getEnvironmentVariable };
+export { readPersistedEnvVar };
 export { validateApiKey };
 export { getLastNCharacters };

--- a/src/utils/spinner.js
+++ b/src/utils/spinner.js
@@ -1,0 +1,25 @@
+// Wraps ora with a unicode-animations braille spinner so every loading state
+// in the CLI shares the same animated braille style.
+import ora from 'ora';
+import spinners from 'unicode-animations';
+
+const DEFAULT_NAME = 'dna';
+
+/**
+ * Drop-in replacement for `ora(text)` / `ora({ text, ... })` that renders with
+ * a braille spinner from `unicode-animations`.
+ *
+ * @param {string|object} opts Either a text string or full ora options.
+ * @param {string} [name='dna'] Any unicode-animations spinner name
+ *   (`braille`, `braillewave`, `dna`, `pulse`, `orbit`, `sparkle`, …).
+ */
+export function brailleOra(opts = {}, name = DEFAULT_NAME) {
+  if (typeof opts === 'string') opts = { text: opts };
+  const sp = spinners[name] || spinners[DEFAULT_NAME];
+  return ora({
+    ...opts,
+    spinner: { frames: sp.frames, interval: sp.interval },
+  });
+}
+
+export default brailleOra;


### PR DESCRIPTION
Brings the npm package up to the 2.0 surface: a real CLI (subcommands, profiles, OAuth) on top of the existing setup wizard, plus a self-healing `doctor` that catches and fixes the most common breakage — tools left holding a key that the backend has since revoked or rotated.

## Highlights

### Auth & accounts (`b6d9caa`, `e9f582f`)
- **OAuth login** — `megallm login` now signs in via the browser. Default flow is RFC 8252 §7.3 loopback (binds 127.0.0.1, opens consent, exchanges the code for an `sk-mega-…` key). Falls back to RFC 8628 device-code with `--no-browser` for headless / SSH.
- **Named profiles** — credentials live under `~/.megallm/profiles/<name>/auth.json` (mirrors `~/.aws/`). Pick with `--profile / -p` or `MEGALLM_PROFILE`.
- **Org awareness** — `megallm orgs`, `megallm switch-org [<id>]` (mints / reuses a per-org key so the saved key is always scoped to the active org), `megallm whoami`, `megallm status`.
- **Key management** — `megallm keys list [--org id]`, `megallm keys revoke <key_id>`.
- **Tool wiring** — `megallm link <tool>` / `megallm unlink <tool>` for one-off Claude / Codex / OpenCode reconfigures, and `megallm setup` still launches the original full wizard.
- **Ink hub** — `megallm` with no args opens an interactive TUI with status panels (account, tools), an animated wordmark banner, rotating tips, and a menu that dispatches to the same subcommand handlers.

### `doctor` — per-tool API key health (`f2c8275`)
- New **"Tools — API key health"** section in `megallm doctor` probes the actual key each configured tool would send to the backend:
  - Claude — read from `~/.claude/settings.json` (`env.ANTHROPIC_API_KEY`).
  - Codex — resolved from the env var its TOML references (`env_key`).
  - OpenCode — resolved from the env var its `{env:NAME}` reference points at.
- Probes against `/userinfo` and reports `active` / `revoked` / `mismatched-with-profile`. A per-key cache means duplicate keys (same key reused across tools and the saved profile) only hit the backend once.
- Identity check now reuses the same prober and gives a clearer message when the saved key was revoked or rotated.
- Environment section now reads the user's shell rc as a fallback so vars persisted but not yet sourced are reported as a green check (with a `source ~/.zshrc` hint) instead of a misleading "not set" warning.

### `doctor fix` — auto-repair (`f2c8275`)
- New **`megallm doctor fix`** subcommand and matching hub menu entry ("Repair tool configs").
- For each installed tool, when its key is missing / revoked / mismatched: re-runs the tool's configurator with the active profile key, and writes the env vars each tool relies on (`ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, `MEGALLM_API_KEY`) to the user's shell rc.
- Refuses to run when the saved profile key itself is dead (suggests `megallm login` instead) — never pushes a known-bad key into a tool.
- **Idempotent**: compares against the rc's persisted value, so re-runs in the same shell are no-ops instead of rewriting the same `export` on every invocation.

### Plumbing
- New `readPersistedEnvVar(name)` in `src/utils/shell.js` — parses bash/zsh `export NAME=VALUE` and fish `set -gx NAME VALUE` from the active shell rc; returns the unquoted value or null. Powers both the doctor improvements and `doctor fix`'s idempotency.

## Why this matters

Re-running `megallm login` rotates the user's CLI key on the backend (re-consent rotation in `mintAndRecord`). Without this PR, the previously-configured tool stays pointing at the now-revoked key and silently 401s in the user's editor. With this PR:

- `megallm doctor` *catches* it (red ✗ on "Claude Code key … is revoked").
- `megallm doctor fix` *repairs* it without re-running the full wizard.
- The hub surfaces both as one-click menu items.

## Verification

```
megallm --version              # 2.8.1
megallm whoami / status        # ok
megallm profile list           # ok
megallm orgs / keys list       # ok
megallm doctor                 # all green, including new key-health section
megallm doctor fix             # idempotent — '3 already healthy' on a clean shell
megallm bogus                  # exits 1 with help
```

Manually exercised against a real revoked-key scenario: re-logged in (which rotated the saved key), confirmed `doctor` flagged Claude as `✗ revoked`, then `doctor fix` swapped `~/.claude/settings.json` to the new key, wrote the three env exports to `~/.zshrc`, and a follow-up `doctor` came back fully green.

## Out of scope / not in this PR
- `src/constants.js` and `src/tui/components.js` had unrelated local edits (a different `OAUTH_CLIENT_ID`, a banner hint URL change). Those were intentionally left out of these commits and should be reviewed/landed separately.